### PR TITLE
Add UVMCLiveLinkMappingAsset for skeletal mesh mapping

### DIFF
--- a/Plugins/VMCLiveLink/Source/VMCLiveLink/Private/VMCLiveLinkMappingAsset.cpp
+++ b/Plugins/VMCLiveLink/Source/VMCLiveLink/Private/VMCLiveLinkMappingAsset.cpp
@@ -1,0 +1,75 @@
+// Copyright (c) 2025 ...
+#include "VMCLiveLinkMappingAsset.h"
+
+#if WITH_EDITOR
+#include "Animation/Skeleton.h"
+#endif
+
+#if WITH_EDITOR
+static FString NormalizeBoneName(FString S)
+{
+	S = S.ToLower();
+	S.ReplaceInline(TEXT("_"), TEXT(""));
+	S.ReplaceInline(TEXT("-"), TEXT(""));
+	return S;
+}
+
+uint32 UVMCLiveLinkMappingAsset::ComputeSignature(const USkeletalMesh* Mesh)
+{
+	if (!Mesh) return 0u;
+
+	const FReferenceSkeleton& RefSkel = Mesh->GetRefSkeleton();
+	TArray<FString> NormNames;
+	NormNames.Reserve(RefSkel.GetNum());
+	for (int32 i = 0; i < RefSkel.GetNum(); ++i)
+	{
+		NormNames.Add(NormalizeBoneName(RefSkel.GetBoneName(i).ToString()));
+	}
+	NormNames.Sort();
+
+	// Stable hash over the normalized sorted set of bone names
+	uint32 H = 1469598103u;
+	for (const FString& N : NormNames)
+	{
+		H = HashCombine(H, GetTypeHash(N));
+	}
+	// Include count for safety
+	H = HashCombine(H, GetTypeHash(RefSkel.GetNum()));
+	return H;
+}
+
+void UVMCLiveLinkMappingAsset::CaptureSignatureFrom(USkeletalMesh* Mesh)
+{
+	if (!Mesh) return;
+	const uint32 Sig = ComputeSignature(Mesh);
+	if (Sig != 0u)
+	{
+		SkeletonSignatures.AddUnique(Sig);
+	}
+	// Keep an example mesh reference too; helps user readability and alternate matching
+	ExampleReferenceMeshes.AddUnique(Mesh);
+	Modify();
+}
+
+bool UVMCLiveLinkMappingAsset::MatchesMesh(USkeletalMesh* Mesh) const
+{
+	if (!Mesh) return false;
+
+	// Direct soft references win
+	for (const TSoftObjectPtr<USkeletalMesh>& Soft : ExampleReferenceMeshes)
+	{
+		if (Soft.ToSoftObjectPath() == Mesh)
+		{
+			return true;
+		}
+		if (USkeletalMesh* L = Soft.Get())
+		{
+			if (L == Mesh) return true;
+		}
+	}
+
+	// Signature match
+	const uint32 Sig = ComputeSignature(Mesh);
+	return Sig != 0u && SkeletonSignatures.Contains(Sig);
+}
+#endif

--- a/Plugins/VMCLiveLink/Source/VMCLiveLink/Public/VMCLiveLinkMappingAsset.h
+++ b/Plugins/VMCLiveLink/Source/VMCLiveLink/Public/VMCLiveLinkMappingAsset.h
@@ -1,0 +1,41 @@
+// Copyright (c) 2025 ...
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Engine/DataAsset.h"
+#include "Engine/SkeletalMesh.h"
+#include "VMCLiveLinkMappingAsset.generated.h"
+
+UCLASS(BlueprintType)
+class VMCLIVELINK_API UVMCLiveLinkMappingAsset : public UDataAsset
+{
+	GENERATED_BODY()
+public:
+	// The reusable maps users will maintain in an asset
+	UPROPERTY(EditAnywhere, Category="Mapping")
+	TMap<FName, FName> BoneNameMap;
+
+	UPROPERTY(EditAnywhere, Category="Mapping")
+	TMap<FName, FName> CurveNameMap;
+
+	// Hint meshes that this mapping applies to (optional; used for auto-detect)
+	UPROPERTY(EditAnywhere, Category="Detection")
+	TArray<TSoftObjectPtr<USkeletalMesh>> ExampleReferenceMeshes;
+
+	// Lightweight signatures of skeletons this mapping applies to (auto-detect)
+	UPROPERTY(EditAnywhere, Category="Detection")
+	TArray<uint32> SkeletonSignatures;
+
+#if WITH_EDITOR
+	// Compute a signature from a mesh and add it to this asset (Call In Editor)
+	UFUNCTION(CallInEditor, Category="Detection")
+	void CaptureSignatureFrom(USkeletalMesh* Mesh);
+
+	// Check if the asset is a match for a given mesh
+	UFUNCTION(BlueprintCallable, Category="Detection")
+	bool MatchesMesh(USkeletalMesh* Mesh) const;
+
+	// Utility: compute a normalized signature for a mesh's RefSkeleton
+	static uint32 ComputeSignature(const USkeletalMesh* Mesh);
+#endif
+};

--- a/Plugins/VMCLiveLink/Source/VMCLiveLink/Public/VMCLiveLinkRemapper.h
+++ b/Plugins/VMCLiveLink/Source/VMCLiveLink/Public/VMCLiveLinkRemapper.h
@@ -9,7 +9,12 @@
 #include "Roles/LiveLinkAnimationRole.h"
 #include "Roles/LiveLinkAnimationTypes.h"
 #include "Engine/SkeletalMesh.h"
+#include "VMCLiveLinkMappingAsset.h" // new
+#if WITH_EDITOR
+#include "UObject/SoftObjectPtr.h"
+#endif
 #include "VMCLiveLinkRemapper.generated.h"
+
 
 UENUM(BlueprintType)
 
@@ -145,6 +150,44 @@ public:
 
 	UFUNCTION(BlueprintCallable, Category = "LiveLink|Remapper")
 	void LoadCustomCurveMapFromJSON(const FString& JsonText);
+
+	// Reusable mapping asset selection
+	UPROPERTY(EditAnywhere, Category = "Remapper|Preset")
+	TSoftObjectPtr<UVMCLiveLinkMappingAsset> MappingAsset;
+
+	// Auto-apply a mapping when ReferenceSkeleton is set/changed (editor)
+	UPROPERTY(EditAnywhere, Category = "Remapper|Preset", meta=(EditConditionHides))
+	bool bAutoDetectMappingFromReference = true;
+
+	// Optional: control capturing signature when saving into the assigned asset
+	UPROPERTY(EditAnywhere, Category = "Remapper|Preset", meta=(DisplayName="Capture Signature On Save"))
+	bool bCaptureSignatureOnSave = true;
+
+	UFUNCTION(BlueprintCallable, Category="LiveLink|Remapper")
+	void ApplyMappingAsset(UVMCLiveLinkMappingAsset* Asset, bool bAlsoCaptureSignature = false);
+
+	// Scans content for mapping assets and applies the first that matches ReferenceSkeleton
+	UFUNCTION(BlueprintCallable, Category="LiveLink|Remapper")
+	bool AutoDetectAndApplyMapping();
+
+	// Save the current maps into an asset (optionally capture signature from ReferenceSkeleton)
+	UFUNCTION(CallInEditor, Category="LiveLink|Remapper")
+	void SaveCurrentMappingTo(UVMCLiveLinkMappingAsset* Asset, bool bCaptureSignatureFromReference);
+
+#if WITH_EDITOR
+	// UX buttons (no-arg, show as buttons in Details)
+	UFUNCTION(CallInEditor, Category="LiveLink|Remapper", meta=(DisplayName="Apply Selected Mapping Asset"))
+	void ApplySelectedMappingAsset();
+
+	UFUNCTION(CallInEditor, Category="LiveLink|Remapper", meta=(DisplayName="Auto Detect and Apply Mapping"))
+	void AutoDetectAndApplyMappingInEditor();
+
+	UFUNCTION(CallInEditor, Category="LiveLink|Remapper", meta=(DisplayName="Save Current Mapping to Assigned Asset"))
+	void SaveCurrentMappingToAssignedAsset();
+
+	UFUNCTION(CallInEditor, Category="LiveLink|Remapper", meta=(DisplayName="Create New Mapping Asset"))
+	void CreateAndAssignNewMappingAsset();
+#endif
 
 public:
 	// NOTE: BoneNameMap is declared on the base (ULiveLinkSubjectRemapper). Don't redeclare it here.

--- a/Plugins/VMCLiveLink/Source/VMCLiveLink/VMCLiveLink.Build.cs
+++ b/Plugins/VMCLiveLink/Source/VMCLiveLink/VMCLiveLink.Build.cs
@@ -6,15 +6,40 @@ public class VMCLiveLink : ModuleRules
     {
         PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
 
-        PublicDependencyModuleNames.AddRange(new[]{
-            "LiveLink","LiveLinkInterface", "LiveLinkAnimationCore",
-            "Core","CoreUObject","Engine", "DeveloperSettings"
+        PublicDependencyModuleNames.AddRange(new[]
+        {
+            "Core",
+            "CoreUObject",
+            "Engine",
+            "LiveLinkInterface",
+            "LiveLink",
+            "OSC",
+
+            // JSON (FJsonValue, FJsonSerializer, FJsonObject etc.)
+            "Json",
+            "JsonUtilities",
+
+            // DeveloperSettings (UDeveloperSettings / project settings)
+            "DeveloperSettings",
+
+            // If you need LiveLink animation helpers / remap types
+            "LiveLinkAnimationCore"
         });
 
-        PrivateDependencyModuleNames.AddRange(new[]{
-          "OSC","Networking","Sockets",
-          "Slate","SlateCore","Json",
-          "JsonUtilities", 
+        PrivateDependencyModuleNames.AddRange(new[]
+        {
+            // used by AutoDetectAndApplyMapping()
+            "AssetRegistry"
         });
+
+        if (Target.bBuildEditor)
+        {
+            PrivateDependencyModuleNames.AddRange(new[]
+            {
+                // Editor-only functionality (creating assets, factories, editor UI)
+                "UnrealEd",
+                "AssetTools"
+            });
+        }
     }
 }

--- a/Plugins/VMCLiveLink/Source/VMCLiveLinkEditor/Private/AssetTypeActions_VMCLiveLinkMappingAsset.cpp
+++ b/Plugins/VMCLiveLink/Source/VMCLiveLinkEditor/Private/AssetTypeActions_VMCLiveLinkMappingAsset.cpp
@@ -1,0 +1,8 @@
+#include "AssetTypeActions_VMCLiveLinkMappingAsset.h"
+#include "VMCLiveLinkMappingAsset.h"
+#include "Modules/ModuleManager.h"
+
+UClass* FAssetTypeActions_VMCLiveLinkMappingAsset::GetSupportedClass() const
+{
+	return UVMCLiveLinkMappingAsset::StaticClass();
+}

--- a/Plugins/VMCLiveLink/Source/VMCLiveLinkEditor/Private/AssetTypeActions_VMCLiveLinkMappingAsset.h
+++ b/Plugins/VMCLiveLink/Source/VMCLiveLinkEditor/Private/AssetTypeActions_VMCLiveLinkMappingAsset.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "AssetTypeActions_Base.h"
+
+class FAssetTypeActions_VMCLiveLinkMappingAsset : public FAssetTypeActions_Base
+{
+public:
+	// IAssetTypeActions
+	virtual FText GetName() const override { return NSLOCTEXT("AssetTypeActions", "VMCLiveLinkMappingAsset", "VMC LiveLink Mapping Asset"); }
+	virtual FColor GetTypeColor() const override { return FColor(0x00A3E8FF); }
+	virtual UClass* GetSupportedClass() const override;
+	virtual uint32 GetCategories() override { return EAssetTypeCategories::Misc; }
+	virtual bool IsImportedAsset() const override { return false; }
+};

--- a/Plugins/VMCLiveLink/Source/VMCLiveLinkEditor/Private/VMCLiveLinkEditorModule.cpp
+++ b/Plugins/VMCLiveLink/Source/VMCLiveLinkEditor/Private/VMCLiveLinkEditorModule.cpp
@@ -1,11 +1,57 @@
 // Copyright (c) 2025 Lifelike & Believable Animation Design, Inc. | Athomas Goldberg. All Rights Reserved.
+#include "VMCLiveLinkEditorModule.h"
 #include "Modules/ModuleManager.h"
+#include "IAssetTools.h"
+#include "AssetToolsModule.h"
+#include "AssetTypeActions_VMCLiveLinkMappingAsset.h"
+
+
+#define LOCTEXT_NAMESPACE "FVMCLiveLinkEditorModule"
+
+static EAssetTypeCategories::Type GVMCLiveLinkAssetCategory = EAssetTypeCategories::Misc;
+
+namespace VMCLiveLinkEditor
+{
+	VMCLIVELINKEDITOR_API EAssetTypeCategories::Type GetAssetCategoryBit()
+	{
+		return GVMCLiveLinkAssetCategory;
+	}
+}
 
 class FVMCLiveLinkEditorModule : public IModuleInterface
 {
 public:
-    virtual void StartupModule() override {}
-    virtual void ShutdownModule() override {}
+	virtual void StartupModule() override
+	{
+#if WITH_EDITOR
+		IAssetTools& AssetTools = FModuleManager::LoadModuleChecked<FAssetToolsModule>("AssetTools").Get();
+		GVMCLiveLinkAssetCategory = AssetTools.RegisterAdvancedAssetCategory(TEXT("VMCLiveLink"), LOCTEXT("VMCLiveLinkCategory", "VMC LiveLink"));
+
+		TSharedRef<FAssetTypeActions_Base> Action = MakeShared<FAssetTypeActions_VMCLiveLinkMappingAsset>();
+		AssetTools.RegisterAssetTypeActions(Action);
+		RegisteredActions.Add(Action);
+#endif
+	}
+
+	virtual void ShutdownModule() override
+	{
+#if WITH_EDITOR
+		if (FModuleManager::Get().IsModuleLoaded("AssetTools"))
+		{
+			IAssetTools& AssetTools = FModuleManager::GetModuleChecked<FAssetToolsModule>("AssetTools").Get();
+			for (auto& Action : RegisteredActions)
+			{
+				AssetTools.UnregisterAssetTypeActions(Action);
+			}
+			RegisteredActions.Empty();
+		}
+#endif
+	}
+
+private:
+	TArray<TSharedRef<FAssetTypeActions_Base>> RegisteredActions;
 };
+
+#undef LOCTEXT_NAMESPACE
 
 IMPLEMENT_MODULE(FVMCLiveLinkEditorModule, VMCLiveLinkEditor)

--- a/Plugins/VMCLiveLink/Source/VMCLiveLinkEditor/Private/VMCLiveLinkEditorModule.h
+++ b/Plugins/VMCLiveLink/Source/VMCLiveLinkEditor/Private/VMCLiveLinkEditorModule.h
@@ -1,0 +1,9 @@
+#pragma once
+#include "CoreMinimal.h"
+#include "IAssetTools.h"
+
+// Exported accessor for the VMCLiveLink asset category bit (registered at module startup)
+namespace VMCLiveLinkEditor
+{
+	VMCLIVELINKEDITOR_API EAssetTypeCategories::Type GetAssetCategoryBit();
+}

--- a/Plugins/VMCLiveLink/Source/VMCLiveLinkEditor/Private/VMCLiveLinkMappingAssetFactory.cpp
+++ b/Plugins/VMCLiveLink/Source/VMCLiveLinkEditor/Private/VMCLiveLinkMappingAssetFactory.cpp
@@ -1,0 +1,25 @@
+#include "VMCLiveLinkMappingAssetFactory.h"
+#include "VMCLiveLinkMappingAsset.h"
+#include "VMCLiveLinkEditorModule.h"
+
+UVMCLiveLinkMappingAssetFactory::UVMCLiveLinkMappingAssetFactory()
+{
+	bCreateNew = true;
+	bEditAfterNew = true;
+	SupportedClass = UVMCLiveLinkMappingAsset::StaticClass();
+}
+
+UObject* UVMCLiveLinkMappingAssetFactory::FactoryCreateNew(UClass* Class, UObject* InParent, FName Name, EObjectFlags Flags, UObject* Context, FFeedbackContext* Warn)
+{
+	return NewObject<UVMCLiveLinkMappingAsset>(InParent, Class, Name, Flags);
+}
+
+uint32 UVMCLiveLinkMappingAssetFactory::GetMenuCategories() const
+{
+	return VMCLiveLinkEditor::GetAssetCategoryBit();
+}
+
+FText UVMCLiveLinkMappingAssetFactory::GetDisplayName() const
+{
+	return NSLOCTEXT("VMCLiveLink", "VMCLiveLinkMappingAssetFactory", "VMC LiveLink Mapping Asset");
+}

--- a/Plugins/VMCLiveLink/Source/VMCLiveLinkEditor/Private/VMCLiveLinkMappingAssetFactory.h
+++ b/Plugins/VMCLiveLink/Source/VMCLiveLinkEditor/Private/VMCLiveLinkMappingAssetFactory.h
@@ -1,0 +1,17 @@
+#pragma once
+#include "CoreMinimal.h"
+#include "Factories/Factory.h"
+#include "VMCLiveLinkMappingAssetFactory.generated.h"
+
+UCLASS()
+class UVMCLiveLinkMappingAssetFactory : public UFactory
+{
+	GENERATED_BODY()
+public:
+	UVMCLiveLinkMappingAssetFactory();
+
+	// UFactory
+	virtual UObject* FactoryCreateNew(UClass* Class, UObject* InParent, FName Name, EObjectFlags Flags, UObject* Context, FFeedbackContext* Warn) override;
+	virtual uint32 GetMenuCategories() const override;
+	virtual FText GetDisplayName() const override;
+};

--- a/Plugins/VMCLiveLink/Source/VMCLiveLinkEditor/VMCLiveLinkEditor.Build.cs
+++ b/Plugins/VMCLiveLink/Source/VMCLiveLinkEditor/VMCLiveLinkEditor.Build.cs
@@ -13,7 +13,7 @@ public class VMCLiveLinkEditor : ModuleRules
         PrivateDependencyModuleNames.AddRange(new[]{
             "VMCLiveLink",          // runtime module
             "LiveLink","LiveLinkInterface","LiveLinkEditor",
-            "Slate","SlateCore","UnrealEd"
+            "Slate","SlateCore","UnrealEd","AssetTools"
         });
     }
 }

--- a/Plugins/VMCLiveLink/VMCLiveLink.uplugin
+++ b/Plugins/VMCLiveLink/VMCLiveLink.uplugin
@@ -16,7 +16,7 @@
 		{
 			"Name": "VMCLiveLinkEditor",
 			"Type": "Editor",
-			"LoadingPhase": "PostEngineInit",
+			"LoadingPhase": "Default",
 			"IncludeListPlatforms": [ "Win64" ]
 		}
 	],


### PR DESCRIPTION
#### PR Classification
New feature implementation for enhanced skeletal mesh mapping and remapping functionality.

#### PR Summary
This pull request introduces new features for the `VMCLiveLinkMappingAsset` and `VMCLiveLinkRemapper` classes, improving the usability and functionality of skeletal mesh mapping in the Unreal Engine editor. Key changes include:
- `VMCLiveLinkMappingAsset.cpp`: Added methods for normalizing bone names and computing signatures from skeletal meshes.
- `VMCLiveLinkRemapper.cpp`: Implemented functionality to apply mapping assets and auto-detect mappings from reference skeletons.
- `VMCLiveLinkMappingAsset.h`: Updated to include properties for bone name and curve name mappings, along with example reference meshes.
- `VMCLiveLinkEditorModule.cpp`: Handled registration and unregistration of new asset type actions during module lifecycle.
- `VMCLiveLinkMappingAssetFactory.cpp`: Enhanced to support the creation of new mapping assets through the editor interface.
