### PR TITLE
Refactor asset type actions for VMC LiveLink mapping

### DIFF
--- a/Plugins/VMCLiveLink/Source/VMCLiveLinkEditor/Private/AssetTypeActions_VMCLiveLinkMappingAsset.cpp
+++ b/Plugins/VMCLiveLink/Source/VMCLiveLinkEditor/Private/AssetTypeActions_VMCLiveLinkMappingAsset.cpp
@@ -1,8 +1,14 @@
 #include "AssetTypeActions_VMCLiveLinkMappingAsset.h"
 #include "VMCLiveLinkMappingAsset.h"
-#include "Modules/ModuleManager.h"
+#include "VMCLiveLinkEditorModule.h"
 
 UClass* FAssetTypeActions_VMCLiveLinkMappingAsset::GetSupportedClass() const
 {
 	return UVMCLiveLinkMappingAsset::StaticClass();
 }
+
+uint32 FAssetTypeActions_VMCLiveLinkMappingAsset::GetCategories()
+{
+	return VMCLiveLinkEditor::GetAssetCategoryBit();
+}
+

--- a/Plugins/VMCLiveLink/Source/VMCLiveLinkEditor/Private/AssetTypeActions_VMCLiveLinkMappingAsset.h
+++ b/Plugins/VMCLiveLink/Source/VMCLiveLinkEditor/Private/AssetTypeActions_VMCLiveLinkMappingAsset.h
@@ -9,6 +9,6 @@ public:
 	virtual FText GetName() const override { return NSLOCTEXT("AssetTypeActions", "VMCLiveLinkMappingAsset", "VMC LiveLink Mapping Asset"); }
 	virtual FColor GetTypeColor() const override { return FColor(0x00A3E8FF); }
 	virtual UClass* GetSupportedClass() const override;
-	virtual uint32 GetCategories() override { return EAssetTypeCategories::Misc; }
+	virtual uint32 GetCategories() override;
 	virtual bool IsImportedAsset() const override { return false; }
 };


### PR DESCRIPTION
#### PR Classification
This pull request introduces a new feature by updating asset category retrieval for the VMC LiveLink Mapping Asset.

#### PR Summary
The changes enhance the `AssetTypeActions_VMCLiveLinkMappingAsset` by modifying header inclusions and updating the asset category retrieval method. 
- `AssetTypeActions_VMCLiveLinkMappingAsset.cpp`: Replaced `Modules/ModuleManager.h` with `VMCLiveLinkEditorModule.h` and added a new `GetCategories()` method.
- `AssetTypeActions_VMCLiveLinkMappingAsset.h`: Changed `GetCategories()` from a fixed return value to a declaration for dynamic category retrieval.
