### PR TITLE
Add VRM spring bone parsing and editor pipeline support

### DIFF
--- a/Plugins/VRMInterchange/Source/VRMInterchange/Private/VRMInterchangeLog.cpp
+++ b/Plugins/VRMInterchange/Source/VRMInterchange/Private/VRMInterchangeLog.cpp
@@ -1,0 +1,3 @@
+#include "VRMInterchangeLog.h"
+
+DEFINE_LOG_CATEGORY(LogVRMSpring);

--- a/Plugins/VRMInterchange/Source/VRMInterchange/Private/VRMSpringBonesParser.cpp
+++ b/Plugins/VRMInterchange/Source/VRMInterchange/Private/VRMSpringBonesParser.cpp
@@ -1,0 +1,397 @@
+#include "VRMSpringBonesParser.h"
+#include "VRMInterchangeLog.h"
+#include "Serialization/JsonSerializer.h"
+#include "Serialization/JsonReader.h"
+#include "Misc/Paths.h"
+#include "Misc/FileHelper.h"
+
+namespace
+{
+    static bool ExtractTopLevelJsonString(const FString& Filename, FString& OutJson)
+    {
+        OutJson.Empty();
+
+        const FString Ext = FPaths::GetExtension(Filename).ToLower();
+        if (Ext == TEXT("gltf"))
+        {
+            return FFileHelper::LoadFileToString(OutJson, *Filename);
+        }
+
+        TArray<uint8> Bytes;
+        if (!FFileHelper::LoadFileToArray(Bytes, *Filename) || Bytes.Num() < 20)
+        {
+            return false;
+        }
+
+        auto ReadLE32 = [](const uint8* p)->uint32
+        {
+            return (uint32)p[0] | ((uint32)p[1] << 8) | ((uint32)p[2] << 16) | ((uint32)p[3] << 24);
+        };
+
+        const uint8* Ptr = Bytes.GetData();
+        const uint32 Magic = ReadLE32(Ptr + 0);
+        const uint32 Version = ReadLE32(Ptr + 4);
+        const uint32 Length = ReadLE32(Ptr + 8);
+        if (Magic != 0x46546C67 || Version != 2 || Length != (uint32)Bytes.Num())
+        {
+            return false;
+        }
+
+        const uint32 Chunk0Len = ReadLE32(Ptr + 12);
+        const uint32 Chunk0Type = ReadLE32(Ptr + 16);
+        if (Bytes.Num() < 20 + (int64)Chunk0Len || Chunk0Type != 0x4E4F534A /*JSON*/)
+        {
+            return false;
+        }
+
+        const uint8* JsonStart = Ptr + 20;
+        int32 JsonLen = (int32)Chunk0Len;
+
+        while (JsonLen > 0 && (JsonStart[JsonLen - 1] == 0 || JsonStart[JsonLen - 1] == ' ' || JsonStart[JsonLen - 1] == '\n' || JsonStart[JsonLen - 1] == '\r' || JsonStart[JsonLen - 1] == '\t'))
+        {
+            --JsonLen;
+        }
+        if (JsonLen <= 0) return false;
+
+        if (JsonLen >= 3 && JsonStart[0] == 0xEF && JsonStart[1] == 0xBB && JsonStart[2] == 0xBF)
+        {
+            JsonStart += 3;
+            JsonLen -= 3;
+        }
+
+        FUTF8ToTCHAR Conv((const ANSICHAR*)JsonStart, JsonLen);
+        OutJson = FString(Conv.Length(), Conv.Get());
+        return !OutJson.IsEmpty();
+    }
+
+    static FVector ReadVec3(const TSharedPtr<FJsonObject>& Obj, const TCHAR* Field, const FVector& Default = FVector::ZeroVector)
+    {
+        const TArray<TSharedPtr<FJsonValue>>* Arr = nullptr;
+        if (!Obj.IsValid() || !Obj->TryGetArrayField(Field, Arr) || !Arr || Arr->Num() < 3) return Default;
+        auto GetF = [](const TSharedPtr<FJsonValue>& V)->double { return V.IsValid() ? V->AsNumber() : 0.0; };
+        return FVector((float)GetF((*Arr)[0]), (float)GetF((*Arr)[1]), (float)GetF((*Arr)[2]));
+    }
+
+    // VRM 1.0
+    static bool ParseVRM1(const TSharedPtr<FJsonObject>& Root, FVRMSpringConfig& Out, FString& OutError)
+    {
+        const TSharedPtr<FJsonObject>* Exts = nullptr;
+        if (!Root->TryGetObjectField(TEXT("extensions"), Exts) || !Exts || !Exts->IsValid())
+        {
+            OutError = TEXT("No 'extensions' for VRM1.");
+            return false;
+        }
+
+        const TSharedPtr<FJsonObject>* Spring = nullptr;
+        if (!(*Exts)->TryGetObjectField(TEXT("VRMC_springBone"), Spring) || !Spring || !Spring->IsValid())
+        {
+            OutError = TEXT("No 'VRMC_springBone' extension.");
+            return false;
+        }
+
+        Out.Spec = EVRMSpringSpec::VRM1;
+
+        // colliders
+        const TArray<TSharedPtr<FJsonValue>>* Colliders = nullptr;
+        if ((*Spring)->TryGetArrayField(TEXT("colliders"), Colliders) && Colliders)
+        {
+            for (const TSharedPtr<FJsonValue>& CV : *Colliders)
+            {
+                const TSharedPtr<FJsonObject>* CObj = nullptr;
+                if (!CV.IsValid() || !CV->TryGetObject(CObj) || !CObj || !CObj->IsValid()) continue;
+
+                FVRMSpringCollider Collider;
+
+                // node refers to glTF node index
+                (*CObj)->TryGetNumberField(TEXT("node"), Collider.NodeIndex);
+
+                const TArray<TSharedPtr<FJsonValue>>* Shapes = nullptr;
+                if ((*CObj)->TryGetArrayField(TEXT("shapes"), Shapes) && Shapes)
+                {
+                    for (const TSharedPtr<FJsonValue>& SV : *Shapes)
+                    {
+                        const TSharedPtr<FJsonObject>* SObj = nullptr;
+                        if (!SV.IsValid() || !SV->TryGetObject(SObj) || !SObj || !SObj->IsValid()) continue;
+
+                        // sphere
+                        const TSharedPtr<FJsonObject>* Sphere = nullptr;
+                        if ((*SObj)->TryGetObjectField(TEXT("sphere"), Sphere) && Sphere && Sphere->IsValid())
+                        {
+                            FVRMSpringColliderSphere S;
+                            S.Offset = ReadVec3(*Sphere, TEXT("offset"));
+                            (*Sphere)->TryGetNumberField(TEXT("radius"), S.Radius);
+                            Collider.Spheres.Add(S);
+                        }
+
+                        // capsule
+                        const TSharedPtr<FJsonObject>* Capsule = nullptr;
+                        if ((*SObj)->TryGetObjectField(TEXT("capsule"), Capsule) && Capsule && Capsule->IsValid())
+                        {
+                            FVRMSpringColliderCapsule C;
+                            C.Offset = ReadVec3(*Capsule, TEXT("offset"));
+                            C.TailOffset = ReadVec3(*Capsule, TEXT("tail"));
+                            (*Capsule)->TryGetNumberField(TEXT("radius"), C.Radius);
+                            Collider.Capsules.Add(C);
+                        }
+                    }
+                }
+
+                Out.Colliders.Add(MoveTemp(Collider));
+            }
+        }
+
+        // colliderGroups
+        const TArray<TSharedPtr<FJsonValue>>* ColliderGroups = nullptr;
+        if ((*Spring)->TryGetArrayField(TEXT("colliderGroups"), ColliderGroups) && ColliderGroups)
+        {
+            for (const TSharedPtr<FJsonValue>& GV : *ColliderGroups)
+            {
+                const TSharedPtr<FJsonObject>* GObj = nullptr;
+                if (!GV.IsValid() || !GV->TryGetObject(GObj) || !GObj || !GObj->IsValid()) continue;
+
+                FVRMSpringColliderGroup Group;
+                (*GObj)->TryGetStringField(TEXT("name"), Group.Name);
+
+                const TArray<TSharedPtr<FJsonValue>>* Indices = nullptr;
+                if ((*GObj)->TryGetArrayField(TEXT("colliders"), Indices) && Indices)
+                {
+                    for (const TSharedPtr<FJsonValue>& IV : *Indices)
+                    {
+                        Group.ColliderIndices.Add((int32)IV->AsNumber());
+                    }
+                }
+                Out.ColliderGroups.Add(MoveTemp(Group));
+            }
+        }
+
+        // joints
+        const TArray<TSharedPtr<FJsonValue>>* Joints = nullptr;
+        if ((*Spring)->TryGetArrayField(TEXT("joints"), Joints) && Joints)
+        {
+            for (const TSharedPtr<FJsonValue>& JV : *Joints)
+            {
+                const TSharedPtr<FJsonObject>* JObj = nullptr;
+                if (!JV.IsValid() || !JV->TryGetObject(JObj) || !JObj || !JObj->IsValid()) continue;
+
+                FVRMSpringJoint J;
+                (*JObj)->TryGetNumberField(TEXT("node"), J.NodeIndex);
+                (*JObj)->TryGetNumberField(TEXT("hitRadius"), J.HitRadius);
+                Out.Joints.Add(MoveTemp(J));
+            }
+        }
+
+        // springs
+        const TArray<TSharedPtr<FJsonValue>>* Springs = nullptr;
+        if ((*Spring)->TryGetArrayField(TEXT("springs"), Springs) && Springs)
+        {
+            for (const TSharedPtr<FJsonValue>& SV : *Springs)
+            {
+                const TSharedPtr<FJsonObject>* SObj = nullptr;
+                if (!SV.IsValid() || !SV->TryGetObject(SObj) || !SObj || !SObj->IsValid()) continue;
+
+                FVRMSpring S;
+                (*SObj)->TryGetStringField(TEXT("name"), S.Name);
+                (*SObj)->TryGetNumberField(TEXT("center"), S.CenterNodeIndex);
+                (*SObj)->TryGetNumberField(TEXT("stiffness"), S.Stiffness);
+                (*SObj)->TryGetNumberField(TEXT("drag"), S.Drag);
+                S.GravityDir = ReadVec3(*SObj, TEXT("gravityDir"), FVector(0, 0, -1));
+                (*SObj)->TryGetNumberField(TEXT("gravityPower"), S.GravityPower);
+                (*SObj)->TryGetNumberField(TEXT("hitRadius"), S.HitRadius);
+
+                const TArray<TSharedPtr<FJsonValue>>* SJ = nullptr;
+                if ((*SObj)->TryGetArrayField(TEXT("joints"), SJ) && SJ)
+                {
+                    for (const TSharedPtr<FJsonValue>& JV : *SJ)
+                    {
+                        S.JointIndices.Add((int32)JV->AsNumber());
+                    }
+                }
+                const TArray<TSharedPtr<FJsonValue>>* CG = nullptr;
+                if ((*SObj)->TryGetArrayField(TEXT("colliderGroups"), CG) && CG)
+                {
+                    for (const TSharedPtr<FJsonValue>& Gv : *CG)
+                    {
+                        S.ColliderGroupIndices.Add((int32)Gv->AsNumber());
+                    }
+                }
+                Out.Springs.Add(MoveTemp(S));
+            }
+        }
+
+        return true;
+    }
+
+    // VRM 0.x
+    static bool ParseVRM0(const TSharedPtr<FJsonObject>& Root, FVRMSpringConfig& Out, FString& OutError)
+    {
+        const TSharedPtr<FJsonObject>* Exts = nullptr;
+        if (!Root->TryGetObjectField(TEXT("extensions"), Exts) || !Exts || !Exts->IsValid())
+        {
+            OutError = TEXT("No 'extensions' for VRM0.");
+            return false;
+        }
+
+        const TSharedPtr<FJsonObject>* VrmObj = nullptr;
+        if (!(*Exts)->TryGetObjectField(TEXT("VRM"), VrmObj) || !VrmObj || !VrmObj->IsValid())
+        {
+            OutError = TEXT("No 'VRM' extension.");
+            return false;
+        }
+
+        const TSharedPtr<FJsonObject>* Sec = nullptr;
+        if (!(*VrmObj)->TryGetObjectField(TEXT("secondaryAnimation"), Sec) || !Sec || !Sec->IsValid())
+        {
+            OutError = TEXT("No 'secondaryAnimation' in VRM 0.x.");
+            return false;
+        }
+
+        Out.Spec = EVRMSpringSpec::VRM0;
+
+        // colliders: flattened from colliderGroups[].colliders (spheres only in 0.x)
+        const TArray<TSharedPtr<FJsonValue>>* ColliderGroups = nullptr;
+        TArray<int32> GroupIndexToFirstCollider;
+        if ((*Sec)->TryGetArrayField(TEXT("colliderGroups"), ColliderGroups) && ColliderGroups)
+        {
+            int32 ColliderBase = 0;
+            for (const TSharedPtr<FJsonValue>& GV : *ColliderGroups)
+            {
+                const TSharedPtr<FJsonObject>* GObj = nullptr;
+                if (!GV.IsValid() || !GV->TryGetObject(GObj) || !GObj || !GObj->IsValid()) continue;
+
+                int32 NodeIndex = INDEX_NONE;
+                (*GObj)->TryGetNumberField(TEXT("node"), NodeIndex);
+
+                FVRMSpringColliderGroup Group;
+                GroupIndexToFirstCollider.Add(ColliderBase);
+
+                const TArray<TSharedPtr<FJsonValue>>* Colliders = nullptr;
+                if ((*GObj)->TryGetArrayField(TEXT("colliders"), Colliders) && Colliders)
+                {
+                    for (const TSharedPtr<FJsonValue>& CV : *Colliders)
+                    {
+                        const TSharedPtr<FJsonObject>* CObj = nullptr;
+                        if (!CV.IsValid() || !CV->TryGetObject(CObj) || !CObj || !CObj->IsValid()) continue;
+
+                        FVRMSpringCollider Collider;
+                        Collider.NodeIndex = NodeIndex;
+
+                        FVRMSpringColliderSphere S;
+                        S.Offset = ReadVec3(*CObj, TEXT("offset"));
+                        (*CObj)->TryGetNumberField(TEXT("radius"), S.Radius);
+                        Collider.Spheres.Add(S);
+
+                        const int32 ThisColliderIndex = Out.Colliders.Num();
+                        Group.ColliderIndices.Add(ThisColliderIndex);
+                        Out.Colliders.Add(MoveTemp(Collider));
+                        ColliderBase++;
+                    }
+                }
+                Out.ColliderGroups.Add(MoveTemp(Group));
+            }
+        }
+
+        // boneGroups -> springs
+        const TArray<TSharedPtr<FJsonValue>>* BoneGroups = nullptr;
+        if ((*Sec)->TryGetArrayField(TEXT("boneGroups"), BoneGroups) && BoneGroups)
+        {
+            for (const TSharedPtr<FJsonValue>& BV : *BoneGroups)
+            {
+                const TSharedPtr<FJsonObject>* BObj = nullptr;
+                if (!BV.IsValid() || !BV->TryGetObject(BObj) || !BObj || !BObj->IsValid()) continue;
+
+                FVRMSpring Spring;
+                (*BObj)->TryGetStringField(TEXT("comment"), Spring.Name);
+                (*BObj)->TryGetNumberField(TEXT("center"), Spring.CenterNodeIndex);
+                (*BObj)->TryGetNumberField(TEXT("stiffiness"), Spring.Stiffness); // some files use 'stiffiness' (typo)
+                (*BObj)->TryGetNumberField(TEXT("stiffness"), Spring.Stiffness);
+                (*BObj)->TryGetNumberField(TEXT("dragForce"), Spring.Drag);
+                Spring.GravityDir = ReadVec3(*BObj, TEXT("gravityDir"), FVector(0, 0, -1));
+                (*BObj)->TryGetNumberField(TEXT("gravityPower"), Spring.GravityPower);
+                (*BObj)->TryGetNumberField(TEXT("hitRadius"), Spring.HitRadius);
+
+                // bones -> we map to Joints + indices
+                const TArray<TSharedPtr<FJsonValue>>* Bones = nullptr;
+                if ((*BObj)->TryGetArrayField(TEXT("bones"), Bones) && Bones)
+                {
+                    for (const TSharedPtr<FJsonValue>& BVV : *Bones)
+                    {
+                        FVRMSpringJoint J;
+                        J.NodeIndex = (int32)BVV->AsNumber();
+                        const int32 JIndex = Out.Joints.Add(J);
+                        Spring.JointIndices.Add(JIndex);
+                    }
+                }
+
+                // colliderGroups indices
+                const TArray<TSharedPtr<FJsonValue>>* CG = nullptr;
+                if ((*BObj)->TryGetArrayField(TEXT("colliderGroups"), CG) && CG)
+                {
+                    for (const TSharedPtr<FJsonValue>& Gv : *CG)
+                    {
+                        Spring.ColliderGroupIndices.Add((int32)Gv->AsNumber());
+                    }
+                }
+
+                Out.Springs.Add(MoveTemp(Spring));
+            }
+        }
+
+        return true;
+    }
+}
+
+namespace VRM
+{
+    bool ParseSpringBonesFromJson(const FString& Json, FVRMSpringConfig& OutConfig, FString& OutError)
+    {
+        OutConfig = FVRMSpringConfig();
+        OutError.Empty();
+
+        if (Json.IsEmpty())
+        {
+            OutError = TEXT("Empty JSON.");
+            return false;
+        }
+
+        TSharedPtr<FJsonObject> Root;
+        const TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Json);
+        if (!FJsonSerializer::Deserialize(Reader, Root) || !Root.IsValid())
+        {
+            OutError = TEXT("Failed to parse JSON.");
+            return false;
+        }
+
+        // Try VRM1 first
+        if (ParseVRM1(Root, OutConfig, OutError))
+        {
+            OutConfig.RawJson = Json;
+            return true;
+        }
+
+        // Reset error, try VRM0
+        FString Err0;
+        FVRMSpringConfig As0;
+        if (ParseVRM0(Root, As0, Err0))
+        {
+            OutConfig = MoveTemp(As0);
+            OutConfig.RawJson = Json;
+            OutError.Reset();
+            return true;
+        }
+
+        // No spring data
+        OutError = TEXT("No VRM spring bone data detected.");
+        return false;
+    }
+
+    bool ParseSpringBonesFromFile(const FString& Filename, FVRMSpringConfig& OutConfig, FString& OutError)
+    {
+        FString Json;
+        if (!ExtractTopLevelJsonString(Filename, Json))
+        {
+            OutError = TEXT("Could not extract top-level JSON from file.");
+            return false;
+        }
+        return ParseSpringBonesFromJson(Json, OutConfig, OutError);
+    }
+}

--- a/Plugins/VRMInterchange/Source/VRMInterchange/Public/VRMInterchangeLog.h
+++ b/Plugins/VRMInterchange/Source/VRMInterchange/Public/VRMInterchangeLog.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "CoreMinimal.h"
+
+VRMINTERCHANGE_API DECLARE_LOG_CATEGORY_EXTERN(LogVRMSpring, Log, All);

--- a/Plugins/VRMInterchange/Source/VRMInterchange/Public/VRMSpringBonesParser.h
+++ b/Plugins/VRMInterchange/Source/VRMInterchange/Public/VRMSpringBonesParser.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "VRMSpringBonesTypes.h"
+
+namespace VRM
+{
+    // Parse from a top-level JSON string (GLB chunk or .gltf text)
+    VRMINTERCHANGE_API bool ParseSpringBonesFromJson(const FString& Json, FVRMSpringConfig& OutConfig, FString& OutError);
+
+    // Convenience: read file (.vrm/.glb/.gltf), extract top-level JSON, parse
+    VRMINTERCHANGE_API bool ParseSpringBonesFromFile(const FString& Filename, FVRMSpringConfig& OutConfig, FString& OutError);
+}

--- a/Plugins/VRMInterchange/Source/VRMInterchange/Public/VRMSpringBonesTypes.h
+++ b/Plugins/VRMInterchange/Source/VRMInterchange/Public/VRMSpringBonesTypes.h
@@ -1,0 +1,116 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "VRMSpringBonesTypes.generated.h"
+
+UENUM()
+enum class EVRMSpringSpec : uint8
+{
+    None,
+    VRM0,
+    VRM1
+};
+
+USTRUCT()
+struct VRMINTERCHANGE_API FVRMSpringColliderSphere
+{
+    GENERATED_BODY()
+
+    UPROPERTY() FVector Offset = FVector::ZeroVector;
+    UPROPERTY() float Radius = 0.f;
+};
+
+USTRUCT()
+struct VRMINTERCHANGE_API FVRMSpringColliderCapsule
+{
+    GENERATED_BODY()
+
+    UPROPERTY() FVector Offset = FVector::ZeroVector;
+    UPROPERTY() float Radius = 0.f;
+    UPROPERTY() FVector TailOffset = FVector::ZeroVector;
+};
+
+USTRUCT()
+struct VRMINTERCHANGE_API FVRMSpringCollider
+{
+    GENERATED_BODY()
+
+    // Node index in glTF (if known)
+    UPROPERTY() int32 NodeIndex = INDEX_NONE;
+    // Optional bone name resolved later
+    UPROPERTY() FName BoneName;
+
+    // Shapes (VRM1 supports multiple shapes per collider)
+    UPROPERTY() TArray<FVRMSpringColliderSphere> Spheres;
+    UPROPERTY() TArray<FVRMSpringColliderCapsule> Capsules;
+};
+
+USTRUCT()
+struct VRMINTERCHANGE_API FVRMSpringColliderGroup
+{
+    GENERATED_BODY()
+
+    UPROPERTY() FString Name;
+    // Indices into Colliders array
+    UPROPERTY() TArray<int32> ColliderIndices;
+};
+
+USTRUCT()
+struct VRMINTERCHANGE_API FVRMSpringJoint
+{
+    GENERATED_BODY()
+
+    // Node index in glTF (if known)
+    UPROPERTY() int32 NodeIndex = INDEX_NONE;
+    // Optional bone name resolved later
+    UPROPERTY() FName BoneName;
+
+    // Per-joint params (normalized)
+    UPROPERTY() float HitRadius = 0.f;
+};
+
+USTRUCT()
+struct VRMINTERCHANGE_API FVRMSpring
+{
+    GENERATED_BODY()
+
+    UPROPERTY() FString Name;
+
+    // Joints composing this spring (indices into Joints)
+    UPROPERTY() TArray<int32> JointIndices;
+
+    // Groups referenced by this spring (indices into ColliderGroups)
+    UPROPERTY() TArray<int32> ColliderGroupIndices;
+
+    // Optional center (node index if known)
+    UPROPERTY() int32 CenterNodeIndex = INDEX_NONE;
+    UPROPERTY() FName CenterBoneName;
+
+    // Spring parameters
+    UPROPERTY() float Stiffness = 0.f;
+    UPROPERTY() float Drag = 0.f;
+    UPROPERTY() FVector GravityDir = FVector(0, 0, -1);
+    UPROPERTY() float GravityPower = 0.f;
+    UPROPERTY() float HitRadius = 0.f;
+};
+
+USTRUCT()
+struct VRMINTERCHANGE_API FVRMSpringConfig
+{
+    GENERATED_BODY()
+
+    UPROPERTY() EVRMSpringSpec Spec = EVRMSpringSpec::None;
+
+    UPROPERTY() TArray<FVRMSpringCollider> Colliders;
+    UPROPERTY() TArray<FVRMSpringColliderGroup> ColliderGroups;
+    UPROPERTY() TArray<FVRMSpringJoint> Joints; // Mainly for VRM1
+    UPROPERTY() TArray<FVRMSpring> Springs;
+
+    // Optional raw JSON copy for diagnostics
+    UPROPERTY() FString RawJson;
+
+    bool IsValid() const
+    {
+        return Spec != EVRMSpringSpec::None && (Springs.Num() > 0 || ColliderGroups.Num() > 0 || Colliders.Num() > 0 || Joints.Num() > 0);
+    }
+};

--- a/Plugins/VRMInterchange/Source/VRMInterchange/VRMInterchange.build.cs
+++ b/Plugins/VRMInterchange/Source/VRMInterchange/VRMInterchange.build.cs
@@ -29,9 +29,10 @@ public class VRMInterchange : ModuleRules
             "StaticMeshDescription",
             "SkeletalMeshDescription", // FSkeletalMeshAttributes and skin weights
             "AnimationCore",           // UE::AnimationCore::FBoneWeights
-            // If you use FStaticMeshOperations in your cpp:
-            // (it lives in StaticMeshDescription; above already covers it)
-            "ImageWrapper" // for ImageWrapperModule.h (used by translator)
+            "ImageWrapper",            // for ImageWrapperModule.h (used by translator)
+            "Json"                     // for FJsonSerializer/FJsonReader/etc.
+            // If you start using FJsonObjectConverter:
+            // "JsonUtilities"
         });
 
         if (Target.bBuildEditor)
@@ -53,7 +54,14 @@ public class VRMInterchange : ModuleRules
                 "ImageWrapper",
                 "Slate",
                 "SlateCore",
-                "Projects"
+                "Projects",
+                "Json", // ensure editor build also links Json
+
+                // <- Editor-only modules required by VRMSpringBonesPostImportPipeline.cpp
+                "AssetRegistry",
+                "AssetTools",
+                // Add "UnrealEd" only if needed (many editor APIs are in UnrealEd)
+                // "UnrealEd",
             });
         }
 

--- a/Plugins/VRMInterchange/Source/VRMInterchangeEditor/Private/VRMInterchangeEditorModule.cpp
+++ b/Plugins/VRMInterchange/Source/VRMInterchangeEditor/Private/VRMInterchangeEditorModule.cpp
@@ -1,0 +1,20 @@
+// Minimal module entry point for the editor module.
+#include "Modules/ModuleManager.h"
+
+class FVRMInterchangeEditorModule : public IModuleInterface
+{
+public:
+    virtual void StartupModule() override
+    {
+        // Keep empty for now. Later phases can register the post-import pipeline here.
+        // Example (when you have a pipeline registrar):
+        // IInterchangeEditorModule::Get().GetPostImportPipelineRegistry().RegisterFactory(...);
+    }
+
+    virtual void ShutdownModule() override
+    {
+        // Unregister anything you registered in StartupModule.
+    }
+};
+
+IMPLEMENT_MODULE(FVRMInterchangeEditorModule, VRMInterchangeEditor)

--- a/Plugins/VRMInterchange/Source/VRMInterchangeEditor/Private/VRMInterchangeSettings.cpp
+++ b/Plugins/VRMInterchange/Source/VRMInterchangeEditor/Private/VRMInterchangeSettings.cpp
@@ -1,0 +1,1 @@
+#include "VRMInterchangeSettings.h"

--- a/Plugins/VRMInterchange/Source/VRMInterchangeEditor/Private/VRMSpringBonesPostImportPipeline.cpp
+++ b/Plugins/VRMInterchange/Source/VRMInterchangeEditor/Private/VRMSpringBonesPostImportPipeline.cpp
@@ -1,0 +1,455 @@
+﻿#include "VRMSpringBonesPostImportPipeline.h"
+#include "VRMSpringBoneData.h"
+
+#include "InterchangeSourceData.h"
+#include "Nodes/InterchangeBaseNodeContainer.h"
+
+#include "AssetRegistry/AssetRegistryModule.h"
+#include "AssetToolsModule.h"
+#include "Factories/Factory.h"
+#include "IAssetTools.h"
+#include "Misc/PackageName.h"
+#include "Misc/Paths.h"
+#include "Misc/FileHelper.h"
+#include "Modules/ModuleManager.h"
+#include "UObject/Package.h"
+#include "Misc/SecureHash.h"
+#include "UObject/SavePackage.h" // SavePackage
+
+// NEW: use shared parser + log category
+#include "VRMSpringBonesParser.h"
+#include "VRMInterchangeLog.h"
+
+// Include cgltf locally to resolve node index -> name
+#define CGLTF_IMPLEMENTATION
+#include "cgltf.h"
+
+// For skeleton validation
+#include "Animation/Skeleton.h"
+#include "Engine/SkeletalMesh.h"
+
+void UVRMSpringBonesPostImportPipeline::ExecutePipeline(UInterchangeBaseNodeContainer* BaseNodeContainer, const TArray<UInterchangeSourceData*>& SourceDatas, const FString& ContentBasePath)
+{
+#if WITH_EDITOR
+    if (!bGenerateSpringBoneData || !BaseNodeContainer)
+    {
+        return;
+    }
+
+    const UInterchangeSourceData* Source = nullptr;
+    if (SourceDatas.Num() > 0)
+    {
+        for (const UInterchangeSourceData* SD : SourceDatas)
+        {
+            if (SD)
+            {
+                Source = SD;
+                break;
+            }
+        }
+    }
+
+    if (!Source)
+    {
+        UE_LOG(LogVRMSpring, Verbose, TEXT("[VRMInterchange] Spring pipeline: No SourceData."));
+        return;
+    }
+
+    const FString Filename = Source->GetFilename();
+
+    // Create or reuse a package under the imported asset path (prefer ContentBasePath)
+    FString PackagePath, AssetName;
+    MakeTargetPathAndName(Filename, ContentBasePath, PackagePath, AssetName);
+
+    // Keep a root search path for skeleton validation (without SubFolder)
+    const FString SkeletonSearchRoot = PackagePath;
+
+    if (!DataAssetName.IsEmpty())
+    {
+        AssetName = DataAssetName;
+    }
+
+    if (!SubFolder.IsEmpty())
+    {
+        PackagePath = PackagePath / SubFolder;
+    }
+
+    // Ensure unique or overwrite as requested
+    FString FinalPackageName = PackagePath / AssetName;
+    if (!bOverwriteExisting)
+    {
+        FAssetToolsModule& AssetToolsModule = FModuleManager::LoadModuleChecked<FAssetToolsModule>("AssetTools");
+        AssetToolsModule.Get().CreateUniqueAssetName(FinalPackageName, TEXT(""), FinalPackageName, AssetName);
+    }
+
+    FString LongPackageName = FinalPackageName;
+    if (!LongPackageName.StartsWith(TEXT("/")))
+    {
+        LongPackageName = TEXT("/") + LongPackageName;
+    }
+
+    // Create the package if needed
+    UPackage* Package = CreatePackage(*LongPackageName);
+    if (!Package)
+    {
+        UE_LOG(LogVRMSpring, Warning, TEXT("[VRMInterchange] Spring pipeline: Failed to create/find package '%s'."), *LongPackageName);
+        return;
+    }
+
+    // Find or create the asset
+    UVRMSpringBoneData* Data = FindObject<UVRMSpringBoneData>(Package, *AssetName);
+    if (!Data)
+    {
+        Data = NewObject<UVRMSpringBoneData>(Package, *AssetName, RF_Public | RF_Standalone);
+    }
+    if (!Data)
+    {
+        UE_LOG(LogVRMSpring, Warning, TEXT("[VRMInterchange] Spring pipeline: Failed to allocate UVRMSpringBoneData."));
+        return;
+    }
+
+    // Fill asset by parsing from file using the shared parser (removes duplicate JSON extraction)
+    if (!ParseAndFillDataAssetFromFile(Filename, Data))
+    {
+        UE_LOG(LogVRMSpring, Verbose, TEXT("[VRMInterchange] Spring pipeline: No spring data found in '%s'."), *Filename);
+        return;
+    }
+
+    // Resolve BoneName / CenterBoneName by re-parsing the source glTF/VRM with cgltf
+    int32 ResolvedColliders = 0, ResolvedJoints = 0, ResolvedCenters = 0;
+    if (!ResolveBoneNamesFromFile(Filename, Data->SpringConfig, ResolvedColliders, ResolvedJoints, ResolvedCenters))
+    {
+        UE_LOG(LogVRMSpring, Verbose, TEXT("[VRMInterchange] Spring pipeline: Could not resolve bone names from '%s'."), *Filename);
+    }
+
+    // Validate resolved names against a USkeleton found under SkeletonSearchRoot
+    ValidateBoneNamesAgainstSkeleton(SkeletonSearchRoot, Data->SpringConfig);
+
+    // Summary logs (spec + counts)
+    {
+        auto SpecToString = [](EVRMSpringSpec S) -> const TCHAR*
+        {
+            switch (S)
+            {
+                case EVRMSpringSpec::VRM0: return TEXT("VRM0");
+                case EVRMSpringSpec::VRM1: return TEXT("VRM1");
+                default: return TEXT("None");
+            }
+        };
+
+        const FVRMSpringConfig& Cfg = Data->SpringConfig;
+        UE_LOG(
+            LogVRMSpring, Log,
+            TEXT("[VRMInterchange] Spring pipeline: Detected spec=%s, Springs=%d, Joints=%d, Colliders=%d, ColliderGroups=%d"),
+            SpecToString(Cfg.Spec),
+            Cfg.Springs.Num(),
+            Cfg.Joints.Num(),
+            Cfg.Colliders.Num(),
+            Cfg.ColliderGroups.Num()
+        );
+
+        // Also log resolution counts
+        int32 SpringsWithCenter = 0;
+        for (const auto& S : Cfg.Springs)
+        {
+            if (S.CenterNodeIndex != INDEX_NONE) { SpringsWithCenter++; }
+        }
+        UE_LOG(
+            LogVRMSpring, Log,
+            TEXT("[VRMInterchange] Spring pipeline: Resolved BoneNames — Colliders %d/%d, Joints %d/%d, Centers %d/%d"),
+            ResolvedColliders, Cfg.Colliders.Num(),
+            ResolvedJoints,   Cfg.Joints.Num(),
+            ResolvedCenters,  SpringsWithCenter
+        );
+    }
+
+    // Save source info
+    Data->SourceFilename = Filename;
+    {
+        const TOptional<FMD5Hash> MaybeHash = Source->GetFileContentHash();
+        if (MaybeHash.IsSet() && MaybeHash->IsValid())
+        {
+            Data->SourceHash = LexToString(MaybeHash.GetValue());
+        }
+        else
+        {
+            Data->SourceHash.Empty();
+        }
+    }
+
+    // Mark and save
+    Data->MarkPackageDirty();
+    FAssetRegistryModule::AssetCreated(Data);
+    Package->SetDirtyFlag(true);
+
+    // Explicitly save package to disk under the imported asset's folder
+    {
+        FString PackageFilename;
+        if (FPackageName::TryConvertLongPackageNameToFilename(LongPackageName, PackageFilename, FPackageName::GetAssetPackageExtension()))
+        {
+            FSavePackageArgs SaveArgs;
+            SaveArgs.TopLevelFlags = RF_Public | RF_Standalone;
+            SaveArgs.SaveFlags = SAVE_NoError;
+            SaveArgs.Error = GError;
+            if (!UPackage::SavePackage(Package, Data, *PackageFilename, SaveArgs))
+            {
+                UE_LOG(LogVRMSpring, Warning, TEXT("[VRMInterchange] Spring pipeline: Failed to save package '%s'."), *LongPackageName);
+            }
+            else
+            {
+                UE_LOG(LogVRMSpring, Verbose, TEXT("[VRMInterchange] Spring pipeline: Saved package '%s'."), *LongPackageName);
+            }
+        }
+        else
+        {
+            UE_LOG(LogVRMSpring, Warning, TEXT("[VRMInterchange] Spring pipeline: Could not convert '%s' to filename for saving."), *LongPackageName);
+        }
+    }
+
+    UE_LOG(LogVRMSpring, Log, TEXT("[VRMInterchange] Spring pipeline: Authored '%s'"), *Data->GetPathName());
+#endif
+}
+
+#if WITH_EDITOR
+// Use shared Phase 1 parser and store normalized config (from file)
+bool UVRMSpringBonesPostImportPipeline::ParseAndFillDataAssetFromFile(const FString& Filename, UVRMSpringBoneData* Dest) const
+{
+    if (!Dest) return false;
+
+    FVRMSpringConfig Config;
+    FString Err;
+    if (!VRM::ParseSpringBonesFromFile(Filename, Config, Err))
+    {
+        return false;
+    }
+
+    Dest->SpringConfig = MoveTemp(Config);
+    return Dest->SpringConfig.IsValid();
+}
+
+FString UVRMSpringBonesPostImportPipeline::MakeTargetPathAndName(const FString& SourceFilename, const FString& ContentBasePath, FString& OutPackagePath, FString& OutAssetName) const
+{
+    // Prefer the import's ContentBasePath (points to the imported asset's folder)
+    if (!ContentBasePath.IsEmpty())
+    {
+        OutPackagePath = ContentBasePath;
+    }
+    else
+    {
+        const FString BaseName = FPaths::GetBaseFilename(SourceFilename);
+        OutPackagePath = FString::Printf(TEXT("/Game/%s"), *BaseName);
+    }
+
+    OutAssetName = TEXT("SpringBonesData");
+    return OutPackagePath / OutAssetName;
+}
+
+// Resolve BoneName and CenterBoneName using cgltf node names
+bool UVRMSpringBonesPostImportPipeline::ResolveBoneNamesFromFile(const FString& Filename, FVRMSpringConfig& InOut, int32& OutResolvedColliders, int32& OutResolvedJoints, int32& OutResolvedCenters) const
+{
+    OutResolvedColliders = 0;
+    OutResolvedJoints = 0;
+    OutResolvedCenters = 0;
+
+    if (!InOut.IsValid())
+    {
+        return false;
+    }
+
+    FTCHARToUTF8 PathUtf8(*Filename);
+    cgltf_options Options = {};
+    cgltf_data* Data = nullptr;
+    const cgltf_result Res = cgltf_parse_file(&Options, PathUtf8.Get(), &Data);
+    if (Res != cgltf_result_success || !Data)
+    {
+        return false;
+    }
+
+    struct FCgltfScopedLocal { cgltf_data* D; ~FCgltfScopedLocal(){ if (D) cgltf_free(D); } } Scoped{ Data };
+
+    const int32 NodesCount = static_cast<int32>(Data->nodes_count);
+    auto GetNodeName = [&](int32 NodeIndex) -> FName
+    {
+        if (NodeIndex < 0 || NodeIndex >= NodesCount) return NAME_None;
+        const cgltf_node* N = &Data->nodes[NodeIndex];
+        if (N && N->name && N->name[0] != '\0')
+        {
+            return FName(UTF8_TO_TCHAR(N->name));
+        }
+        return NAME_None;
+    };
+
+    // Colliders
+    for (FVRMSpringCollider& C : InOut.Colliders)
+    {
+        if (C.BoneName.IsNone() && C.NodeIndex != INDEX_NONE)
+        {
+            const FName Name = GetNodeName(C.NodeIndex);
+            if (!Name.IsNone())
+            {
+                C.BoneName = Name;
+                ++OutResolvedColliders;
+            }
+        }
+    }
+
+    // Joints
+    for (FVRMSpringJoint& J : InOut.Joints)
+    {
+        if (J.BoneName.IsNone() && J.NodeIndex != INDEX_NONE)
+        {
+            const FName Name = GetNodeName(J.NodeIndex);
+            if (!Name.IsNone())
+            {
+                J.BoneName = Name;
+                ++OutResolvedJoints;
+            }
+        }
+    }
+
+    // Springs centers
+    for (FVRMSpring& S : InOut.Springs)
+    {
+        if (S.CenterBoneName.IsNone() && S.CenterNodeIndex != INDEX_NONE)
+        {
+            const FName Name = GetNodeName(S.CenterNodeIndex);
+            if (!Name.IsNone())
+            {
+                S.CenterBoneName = Name;
+                ++OutResolvedCenters;
+            }
+        }
+    }
+
+    return (OutResolvedColliders + OutResolvedJoints + OutResolvedCenters) > 0;
+}
+
+// Validate BoneNames against a USkeleton under the imported asset's folder
+void UVRMSpringBonesPostImportPipeline::ValidateBoneNamesAgainstSkeleton(const FString& SearchRootPackagePath, const FVRMSpringConfig& Config) const
+{
+    if (SearchRootPackagePath.IsEmpty())
+    {
+        UE_LOG(LogVRMSpring, Verbose, TEXT("[VRMInterchange] Spring pipeline: No ContentBasePath; skipping skeleton validation."));
+        return;
+    }
+
+    FAssetRegistryModule& ARM = FModuleManager::LoadModuleChecked<FAssetRegistryModule>("AssetRegistry");
+
+    // Try to find a USkeleton first
+    FARFilter Filter;
+    Filter.bRecursivePaths = true;
+    Filter.PackagePaths.Add(*SearchRootPackagePath);
+    Filter.ClassPaths.Add(USkeleton::StaticClass()->GetClassPathName());
+
+    TArray<FAssetData> Found;
+    ARM.Get().GetAssets(Filter, Found);
+
+    USkeleton* Skeleton = nullptr;
+
+    if (Found.Num() > 0)
+    {
+        // Load the first skeleton found
+        Skeleton = Cast<USkeleton>(Found[0].GetAsset());
+    }
+    else
+    {
+        // Fallback: find a USkeletalMesh and get its skeleton
+        FARFilter MeshFilter;
+        MeshFilter.bRecursivePaths = true;
+        MeshFilter.PackagePaths.Add(*SearchRootPackagePath);
+        MeshFilter.ClassPaths.Add(USkeletalMesh::StaticClass()->GetClassPathName());
+
+        TArray<FAssetData> Meshes;
+        ARM.Get().GetAssets(MeshFilter, Meshes);
+        if (Meshes.Num() > 0)
+        {
+            if (USkeletalMesh* SkelMesh = Cast<USkeletalMesh>(Meshes[0].GetAsset()))
+            {
+                Skeleton = SkelMesh->GetSkeleton();
+            }
+        }
+    }
+
+    if (!Skeleton)
+    {
+        UE_LOG(LogVRMSpring, Verbose, TEXT("[VRMInterchange] Spring pipeline: No USkeleton found under '%s' for validation."), *SearchRootPackagePath);
+        return;
+    }
+
+    // Build a set of valid bone names
+    const FReferenceSkeleton& RefSkel = Skeleton->GetReferenceSkeleton();
+    TSet<FName> ValidBones;
+    ValidBones.Reserve(RefSkel.GetNum());
+    for (int32 i = 0; i < RefSkel.GetNum(); ++i)
+    {
+        ValidBones.Add(RefSkel.GetBoneName(i));
+    }
+
+    // Collect mismatches
+    TArray<FName> MissingColliders;
+    TArray<FName> MissingJoints;
+    TArray<FName> MissingCenters;
+
+    for (const FVRMSpringCollider& C : Config.Colliders)
+    {
+        if (!C.BoneName.IsNone() && !ValidBones.Contains(C.BoneName))
+        {
+            MissingColliders.AddUnique(C.BoneName);
+        }
+    }
+    for (const FVRMSpringJoint& J : Config.Joints)
+    {
+        if (!J.BoneName.IsNone() && !ValidBones.Contains(J.BoneName))
+        {
+            MissingJoints.AddUnique(J.BoneName);
+        }
+    }
+    for (const FVRMSpring& S : Config.Springs)
+    {
+        if (!S.CenterBoneName.IsNone() && !ValidBones.Contains(S.CenterBoneName))
+        {
+            MissingCenters.AddUnique(S.CenterBoneName);
+        }
+    }
+
+    auto JoinNames = [](const TArray<FName>& Names)->FString
+    {
+        FString Out;
+        const int32 MaxList = 12; // cap output
+        const int32 Count = Names.Num();
+        for (int32 i = 0; i < Count && i < MaxList; ++i)
+        {
+            if (i) Out += TEXT(", ");
+            Out += Names[i].ToString();
+        }
+        if (Count > MaxList)
+        {
+            Out += FString::Printf(TEXT(", +%d more"), Count - MaxList);
+        }
+        return Out;
+    };
+
+    if (MissingColliders.Num() == 0 && MissingJoints.Num() == 0 && MissingCenters.Num() == 0)
+    {
+        UE_LOG(LogVRMSpring, Verbose, TEXT("[VRMInterchange] Spring pipeline: All resolved BoneNames validated against '%s'."), *Skeleton->GetPathName());
+    }
+    else
+    {
+        if (MissingColliders.Num() > 0)
+        {
+            UE_LOG(LogVRMSpring, Warning, TEXT("[VRMInterchange] Spring pipeline: %d collider BoneName(s) not found on skeleton '%s': %s"),
+                MissingColliders.Num(), *Skeleton->GetPathName(), *JoinNames(MissingColliders));
+        }
+        if (MissingJoints.Num() > 0)
+        {
+            UE_LOG(LogVRMSpring, Warning, TEXT("[VRMInterchange] Spring pipeline: %d joint BoneName(s) not found on skeleton '%s': %s"),
+                MissingJoints.Num(), *Skeleton->GetPathName(), *JoinNames(MissingJoints));
+        }
+        if (MissingCenters.Num() > 0)
+        {
+            UE_LOG(LogVRMSpring, Warning, TEXT("[VRMInterchange] Spring pipeline: %d center BoneName(s) not found on skeleton '%s': %s"),
+                MissingCenters.Num(), *Skeleton->GetPathName(), *JoinNames(MissingCenters));
+        }
+    }
+}
+#endif

--- a/Plugins/VRMInterchange/Source/VRMInterchangeEditor/Private/VRMSpringBonesPostImportPipeline.h
+++ b/Plugins/VRMInterchange/Source/VRMInterchangeEditor/Private/VRMSpringBonesPostImportPipeline.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "InterchangePipelineBase.h"
+#include "VRMSpringBonesPostImportPipeline.generated.h"
+
+// Forward declarations to avoid including heavy headers here
+class UInterchangeBaseNodeContainer;
+class UInterchangeSourceData;
+class UVRMSpringBoneData;
+class USkeleton;
+struct FVRMSpringConfig;
+
+UCLASS()
+class UVRMSpringBonesPostImportPipeline : public UInterchangePipelineBase
+{
+    GENERATED_BODY()
+public:
+#if WITH_EDITOR
+    // Visible toggle in Project Settings > Interchange > Pipelines
+    UPROPERTY(EditAnywhere, Category = "VRM Spring")
+    bool bGenerateSpringBoneData = false;
+
+    // Create or overwrite existing asset with same name
+    UPROPERTY(EditAnywhere, Category = "VRM Spring")
+    bool bOverwriteExisting = false;
+
+    // Folder suffix under the root imported package
+    UPROPERTY(EditAnywhere, Category = "VRM Spring")
+    FString SubFolder = TEXT("SpringBones");
+
+    // Base name of the data asset
+    UPROPERTY(EditAnywhere, Category = "VRM Spring")
+    FString DataAssetName = TEXT("SpringBonesData");
+#endif
+
+    // UInterchangePipelineBase
+    virtual void ExecutePipeline(UInterchangeBaseNodeContainer* BaseNodeContainer, const TArray<UInterchangeSourceData*>& SourceDatas, const FString& ContentBasePath) override;
+
+private:
+#if WITH_EDITOR
+    // Parse and fill directly from source file (delegates JSON extraction to shared parser)
+    bool ParseAndFillDataAssetFromFile(const FString& Filename, UVRMSpringBoneData* Dest) const;
+
+    // Use ContentBasePath when available; fallback to /Game/<VRMBaseName>
+    FString MakeTargetPathAndName(const FString& SourceFilename, const FString& ContentBasePath, FString& OutPackagePath, FString& OutAssetName) const;
+
+    // Resolve BoneName from glTF node indices using cgltf (editor-only)
+    bool ResolveBoneNamesFromFile(const FString& Filename, FVRMSpringConfig& InOut, int32& OutResolvedColliders, int32& OutResolvedJoints, int32& OutResolvedCenters) const;
+
+    // Validate resolved BoneNames against a USkeleton found under the imported asset's folder
+    void ValidateBoneNamesAgainstSkeleton(const FString& SearchRootPackagePath, const FVRMSpringConfig& Config) const;
+#endif
+};
+

--- a/Plugins/VRMInterchange/Source/VRMInterchangeEditor/Public/VRMInterchangeSettings.h
+++ b/Plugins/VRMInterchange/Source/VRMInterchangeEditor/Public/VRMInterchangeSettings.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Engine/DeveloperSettings.h"
+#include "VRMInterchangeSettings.generated.h"
+
+UCLASS(config=EditorPerProjectUserSettings, defaultconfig, meta=(DisplayName="VRM Interchange"))
+class VRMINTERCHANGEEDITOR_API UVRMInterchangeSettings : public UDeveloperSettings
+{
+    GENERATED_BODY()
+public:
+    UPROPERTY(EditAnywhere, config, Category="Spring Bones", meta=(ToolTip="Parse and generate spring bone data assets during import."))
+    bool bGenerateSpringBoneData = false;
+
+    UPROPERTY(EditAnywhere, config, Category="Spring Bones", meta=(ToolTip="Duplicate and assign a Post-Process AnimBP to drive springs."))
+    bool bGeneratePostProcessAnimBP = false;
+
+    UPROPERTY(EditAnywhere, config, Category="Spring Bones", meta=(ToolTip="Assign generated Post-Process AnimBP to the imported SkeletalMesh."))
+    bool bAssignPostProcessABP = false;
+
+    UPROPERTY(EditAnywhere, config, Category="Spring Bones", meta=(ToolTip="If true, overwrite existing generated spring assets. If false, create with a suffix."))
+    bool bOverwriteExistingSpringAssets = false;
+
+    virtual FName GetCategoryName() const override { return TEXT("Plugins"); }
+};

--- a/Plugins/VRMInterchange/Source/VRMInterchangeEditor/Public/VRMSpringBoneData.h
+++ b/Plugins/VRMInterchange/Source/VRMInterchangeEditor/Public/VRMSpringBoneData.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Engine/DataAsset.h"
+#include "VRMSpringBonesTypes.h"
+#include "VRMSpringBoneData.generated.h"
+
+// Editor-only data asset that stores parsed spring bone configuration,
+// plus optional provenance information for regeneration/debugging.
+UCLASS(BlueprintType)
+class VRMINTERCHANGEEDITOR_API UVRMSpringBoneData : public UDataAsset
+{
+    GENERATED_BODY()
+public:
+    // Parsed and normalized spring bone configuration (runtime-shared type)
+    UPROPERTY(EditAnywhere, Category="Spring Bones")
+    FVRMSpringConfig SpringConfig;
+
+    // Optional source info for staleness checks / diagnostics
+    UPROPERTY(VisibleAnywhere, Category="Spring Bones")
+    FString SourceHash;
+
+    UPROPERTY(VisibleAnywhere, Category="Spring Bones")
+    FString SourceFilename;
+};

--- a/Plugins/VRMInterchange/Source/VRMInterchangeEditor/VRMInterchangeEditor.build.cs
+++ b/Plugins/VRMInterchange/Source/VRMInterchangeEditor/VRMInterchangeEditor.build.cs
@@ -1,0 +1,61 @@
+using UnrealBuildTool;
+using System.IO;
+
+public class VRMInterchangeEditor : ModuleRules
+{
+    public VRMInterchangeEditor(ReadOnlyTargetRules Target) : base(Target)
+    {
+        // Editor-only
+        if (!Target.bBuildEditor)
+        {
+            throw new BuildException("VRMInterchangeEditor is editor-only.");
+        }
+
+        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
+
+        PublicDependencyModuleNames.AddRange(new string[]
+        {
+            "Core",
+            "CoreUObject",
+            "Engine",
+        });
+
+        PrivateDependencyModuleNames.AddRange(new string[]
+        {
+            // Interchange
+            "InterchangeCore",
+            "InterchangeEngine",
+            "InterchangeEditor",
+            "InterchangeNodes",
+            "InterchangeFactoryNodes",
+            "DeveloperSettings",
+            // Asset authoring
+            "AssetRegistry",
+            "AssetTools",
+            "UnrealEd",     // for package/asset creation utilities
+
+            // We parse JSON directly from the VRM/GLB container
+            "Json",
+
+            "Projects",
+
+            // Runtime plugin module this editor module depends on
+            "VRMInterchange",
+        });
+
+        // We share some includes with the runtime module (optional)
+        PrivateIncludePaths.AddRange(new string[]
+        {
+            Path.Combine(ModuleDirectory, "..", "VRMInterchange", "Public"),
+            Path.Combine(ModuleDirectory, "Private")
+        });
+
+        // Add ThirdParty include path for cgltf (put cgltf.h into Plugins/VRMInterchange/ThirdParty/cgltf/)
+        string ThirdPartyCgltf = Path.Combine(ModuleDirectory, "..", "..", "ThirdParty", "cgltf");
+        if (Directory.Exists(ThirdPartyCgltf))
+        {
+            PrivateIncludePaths.Add(ThirdPartyCgltf);
+        }
+    }
+
+}

--- a/Plugins/VRMInterchange/VRMInterchange.uplugin
+++ b/Plugins/VRMInterchange/VRMInterchange.uplugin
@@ -8,6 +8,11 @@
   "Modules": [
     {
       "Name": "VRMInterchange",
+      "Type": "Runtime",
+      "LoadingPhase": "Default"
+    },
+    {
+      "Name": "VRMInterchangeEditor",
       "Type": "Editor",
       "LoadingPhase": "Default"
     }


### PR DESCRIPTION
Add VRM spring bone parsing and editor pipeline support

Introduced functionality to parse and handle VRM spring bone data
from `.vrm`, `.gltf`, or `.glb` files, supporting both VRM 1.0 and
VRM 0.x specifications. Added new data structures to represent
spring bone configurations, including colliders, joints, springs,
and collider groups.

Implemented an editor module (`VRMInterchangeEditor`) with a
post-import pipeline to generate spring bone data assets. Added
support for resolving bone names using `cgltf` and validating
against `USkeleton`. Created `UVRMSpringBoneData` to store parsed
spring bone configurations and provenance information.

Exposed developer settings for spring bone generation in the
editor's project settings. Updated build files to include
dependencies for JSON parsing, asset tools, and editor utilities.
Enhanced logging and error handling for debugging.

Ensured compatibility with Unreal Engine's Interchange framework
and improved code organization with dedicated namespaces and
utility functions.