### PR TITLE
New feature: Added support for parsing and generating spring bone data from VRM files, along with post-import processing and validation.

### DIFF
--- a/Config/DefaultEditorPerProjectUserSettings.ini
+++ b/Config/DefaultEditorPerProjectUserSettings.ini
@@ -1,0 +1,5 @@
+
+
+[/Script/VRMInterchangeEditor.VRMInterchangeSettings]
+bGenerateSpringBoneData=True
+

--- a/Plugins/VRMInterchange/Source/VRMInterchangeEditor/Private/Tests/VRMSpringBonesNameResolveTests.cpp
+++ b/Plugins/VRMInterchange/Source/VRMInterchangeEditor/Private/Tests/VRMSpringBonesNameResolveTests.cpp
@@ -1,0 +1,93 @@
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "Misc/AutomationTest.h"
+#include "Misc/Paths.h"
+#include "Misc/FileHelper.h"
+#include "VRMSpringBonesTypes.h"
+
+// Local cgltf include (editor module has ThirdParty include path)
+#include "cgltf.h"
+
+static bool LocalResolveNamesFromGltf(const FString& Filename, FVRMSpringConfig& InOut)
+{
+    FTCHARToUTF8 PathUtf8(*Filename);
+    cgltf_options Options = {};
+    cgltf_data* Data = nullptr;
+    const cgltf_result Res = cgltf_parse_file(&Options, PathUtf8.Get(), &Data);
+    if (Res != cgltf_result_success || !Data) return false;
+    struct FScoped { cgltf_data* D; ~FScoped(){ if (D) cgltf_free(D); } } Scoped{ Data };
+
+    const int32 NodesCount = static_cast<int32>(Data->nodes_count);
+    auto GetNodeName = [&](int32 NodeIndex)->FName
+    {
+        if (NodeIndex < 0 || NodeIndex >= NodesCount) return NAME_None;
+        const cgltf_node* N = &Data->nodes[NodeIndex];
+        return (N && N->name && N->name[0] != '\0') ? FName(UTF8_TO_TCHAR(N->name)) : NAME_None;
+    };
+
+    for (auto& C : InOut.Colliders)
+        if (C.BoneName.IsNone() && C.NodeIndex != INDEX_NONE)
+            C.BoneName = GetNodeName(C.NodeIndex);
+
+    for (auto& J : InOut.Joints)
+        if (J.BoneName.IsNone() && J.NodeIndex != INDEX_NONE)
+            J.BoneName = GetNodeName(J.NodeIndex);
+
+    for (auto& S : InOut.Springs)
+        if (S.CenterBoneName.IsNone() && S.CenterNodeIndex != INDEX_NONE)
+            S.CenterBoneName = GetNodeName(S.CenterNodeIndex);
+
+    return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FVRMResolveNamesFromGltf, "VRM.SpringBones.ResolveNamesFromGltf",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FVRMResolveNamesFromGltf::RunTest(const FString& Parameters)
+{
+    // Create a minimal .gltf on disk with 3 named nodes
+    const FString TempDir = FPaths::ProjectSavedDir() / TEXT("VRMTests");
+    IFileManager::Get().MakeDirectory(*TempDir, true);
+    const FString GltfPath = TempDir / TEXT("NodesOnly.gltf");
+    const FString GltfJson = TEXT(R"JSON(
+    {
+      "asset": {"version":"2.0"},
+      "nodes": [
+        { "name":"Center" },
+        { "name":"Head" },
+        { "name":"Hair_01" }
+      ]
+    })JSON");
+    if (!FFileHelper::SaveStringToFile(GltfJson, *GltfPath))
+    {
+        AddError(TEXT("Failed to write temporary .gltf"));
+        return false;
+    }
+
+    // Build a config that references those node indices
+    FVRMSpringConfig Cfg;
+    Cfg.Spec = EVRMSpringSpec::VRM1;
+
+    FVRMSpringCollider Collider;
+    Collider.NodeIndex = 1; // Head
+    Cfg.Colliders.Add(Collider);
+
+    FVRMSpringJoint Joint;
+    Joint.NodeIndex = 2; // Hair_01
+    Cfg.Joints.Add(Joint);
+
+    FVRMSpring Spring;
+    Spring.CenterNodeIndex = 0; // Center
+    Spring.JointIndices = { 0 }; // references Cfg.Joints[0]
+    Cfg.Springs.Add(Spring);
+
+    const bool bResolved = LocalResolveNamesFromGltf(GltfPath, Cfg);
+    TestTrue(TEXT("ResolveNames succeeded"), bResolved);
+    TestEqual(TEXT("Collider BoneName == Head"), Cfg.Colliders[0].BoneName, FName(TEXT("Head")));
+    TestEqual(TEXT("Joint BoneName == Hair_01"), Cfg.Joints[0].BoneName, FName(TEXT("Hair_01")));
+    TestEqual(TEXT("Spring CenterBoneName == Center"), Cfg.Springs[0].CenterBoneName, FName(TEXT("Center")));
+
+    return true;
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS

--- a/Plugins/VRMInterchange/Source/VRMInterchangeEditor/Private/Tests/VRMSpringBonesParserTests.cpp
+++ b/Plugins/VRMInterchange/Source/VRMInterchangeEditor/Private/Tests/VRMSpringBonesParserTests.cpp
@@ -1,0 +1,104 @@
+// Builds in Editor only
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "Misc/AutomationTest.h"
+#include "VRMSpringBonesParser.h"
+#include "VRMSpringBonesTypes.h"
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FVRMParseVRM1Json, "VRM.SpringBones.Parse.VRM1",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FVRMParseVRM1Json::RunTest(const FString& Parameters)
+{
+    // Minimal VRM1 springBone JSON
+    const FString Json = TEXT(R"JSON(
+    {
+      "asset": {"version":"2.0"},
+      "extensions": {
+        "VRMC_springBone": {
+          "colliders": [
+            { "node": 1, "shapes": [ { "sphere": { "offset":[0,0,0], "radius": 0.02 } } ] }
+          ],
+          "colliderGroups": [
+            { "name": "HeadCG", "colliders": [ 0 ] }
+          ],
+          "joints": [
+            { "node": 2, "hitRadius": 0.01 }
+          ],
+          "springs": [
+            {
+              "name":"Hair",
+              "center": 0,
+              "stiffness": 0.8,
+              "drag": 0.2,
+              "gravityDir": [0,0,-1],
+              "gravityPower": 1.0,
+              "hitRadius": 0.03,
+              "joints": [0],
+              "colliderGroups": [0]
+            }
+          ]
+        }
+      }
+    })JSON");
+
+    FVRMSpringConfig Cfg;
+    FString Err;
+    const bool bOk = VRM::ParseSpringBonesFromJson(Json, Cfg, Err);
+    TestTrue(TEXT("Parse VRM1 JSON"), bOk);
+    TestEqual(TEXT("Spec == VRM1"), (int32)Cfg.Spec, (int32)EVRMSpringSpec::VRM1);
+    TestEqual(TEXT("Colliders"), Cfg.Colliders.Num(), 1);
+    TestEqual(TEXT("ColliderGroups"), Cfg.ColliderGroups.Num(), 1);
+    TestEqual(TEXT("Joints"), Cfg.Joints.Num(), 1);
+    TestEqual(TEXT("Springs"), Cfg.Springs.Num(), 1);
+    TestTrue(TEXT("IsValid()"), Cfg.IsValid());
+    return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FVRMParseVRM0Json, "VRM.SpringBones.Parse.VRM0",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FVRMParseVRM0Json::RunTest(const FString& Parameters)
+{
+    // Minimal VRM0 secondaryAnimation JSON
+    const FString Json = TEXT(R"JSON(
+    {
+      "asset": {"version":"2.0"},
+      "extensions": {
+        "VRM": {
+          "secondaryAnimation": {
+            "colliderGroups": [
+              { "node": 1, "colliders": [ { "offset":[0,0,0], "radius": 0.02 } ] }
+            ],
+            "boneGroups": [
+              {
+                "comment": "Hair",
+                "center": 0,
+                "stiffness": 0.7,
+                "dragForce": 0.2,
+                "gravityDir": [0,0,-1],
+                "gravityPower": 1.0,
+                "hitRadius": 0.03,
+                "bones": [ 2 ],
+                "colliderGroups": [ 0 ]
+              }
+            ]
+          }
+        }
+      }
+    })JSON");
+
+    FVRMSpringConfig Cfg;
+    FString Err;
+    const bool bOk = VRM::ParseSpringBonesFromJson(Json, Cfg, Err);
+    TestTrue(TEXT("Parse VRM0 JSON"), bOk);
+    TestEqual(TEXT("Spec == VRM0"), (int32)Cfg.Spec, (int32)EVRMSpringSpec::VRM0);
+    TestEqual(TEXT("Colliders"), Cfg.Colliders.Num(), 1);
+    TestEqual(TEXT("ColliderGroups"), Cfg.ColliderGroups.Num(), 1);
+    TestEqual(TEXT("Springs"), Cfg.Springs.Num(), 1);
+    TestTrue(TEXT("Joints synthesized"), Cfg.Joints.Num() >= 1);
+    TestTrue(TEXT("IsValid()"), Cfg.IsValid());
+    return true;
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS

--- a/Plugins/VRMInterchange/Source/VRMInterchangeEditor/Private/VRMInterchangeEditorModule.cpp
+++ b/Plugins/VRMInterchange/Source/VRMInterchangeEditor/Private/VRMInterchangeEditorModule.cpp
@@ -1,19 +1,42 @@
 // Minimal module entry point for the editor module.
 #include "Modules/ModuleManager.h"
+#include "VRMSpringBonesPostImportPipeline.h"
+#include "InterchangeManager.h"
+#include "UObject/UObjectIterator.h"
+#include "UObject/Class.h"
+#include "InterchangePipelineBase.h"
 
 class FVRMInterchangeEditorModule : public IModuleInterface
 {
 public:
     virtual void StartupModule() override
     {
-        // Keep empty for now. Later phases can register the post-import pipeline here.
-        // Example (when you have a pipeline registrar):
-        // IInterchangeEditorModule::Get().GetPostImportPipelineRegistry().RegisterFactory(...);
+        // Ensure the pipeline class is linked into the module binary
+        UVRMSpringBonesPostImportPipeline::StaticClass();
+
+        UE_LOG(LogTemp, Log, TEXT("VRMInterchangeEditor module started"));
+
+#if WITH_EDITOR
+        // Enumerate all loaded UClasses derived from UInterchangePipelineBase
+        const UClass* PipelineBase = UInterchangePipelineBase::StaticClass();
+        int32 Found = 0;
+        for (TObjectIterator<UClass> It; It; ++It)
+        {
+            UClass* C = *It;
+            if (!C->HasAnyClassFlags(CLASS_Deprecated) && C->IsChildOf(PipelineBase))
+            {
+                ++Found;
+                const bool bIsTarget = (C == UVRMSpringBonesPostImportPipeline::StaticClass());
+                UE_LOG(LogTemp, Log, TEXT("Interchange Pipeline subclass found: %s%s"), *C->GetName(), bIsTarget ? TEXT("  <-- target") : TEXT(""));
+            }
+        }
+        UE_LOG(LogTemp, Log, TEXT("Interchange Pipeline subclasses enumerated: %d"), Found);
+#endif
     }
 
     virtual void ShutdownModule() override
     {
-        // Unregister anything you registered in StartupModule.
+        UE_LOG(LogTemp, Log, TEXT("VRMInterchangeEditor module shutdown"));
     }
 };
 

--- a/Plugins/VRMInterchange/Source/VRMInterchangeEditor/Private/VRMInterchangeSettings.cpp
+++ b/Plugins/VRMInterchange/Source/VRMInterchangeEditor/Private/VRMInterchangeSettings.cpp
@@ -1,1 +1,14 @@
 #include "VRMInterchangeSettings.h"
+
+
+UVRMInterchangeSettings::UVRMInterchangeSettings()
+{
+	// helps where it appears in the Settings tree (optional)
+	CategoryName = TEXT("Plugins");
+	SectionName = TEXT("VRM Interchange");
+	// Sensible defaults
+	bGenerateSpringBoneData = false;
+	bGeneratePostProcessAnimBP = false;
+	bAssignPostProcessABP = false;
+	bOverwriteExistingSpringAssets = false;
+}

--- a/Plugins/VRMInterchange/Source/VRMInterchangeEditor/Private/VRMSpringBonesPostImportPipeline.h
+++ b/Plugins/VRMInterchange/Source/VRMInterchangeEditor/Private/VRMSpringBonesPostImportPipeline.h
@@ -1,35 +1,33 @@
 #pragma once
 
 #include "CoreMinimal.h"
+// Use the generic Interchange pipeline base (available across versions)
 #include "InterchangePipelineBase.h"
 #include "VRMSpringBonesPostImportPipeline.generated.h"
 
-// Forward declarations to avoid including heavy headers here
 class UInterchangeBaseNodeContainer;
 class UInterchangeSourceData;
 class UVRMSpringBoneData;
 class USkeleton;
 struct FVRMSpringConfig;
 
-UCLASS()
-class UVRMSpringBonesPostImportPipeline : public UInterchangePipelineBase
+UCLASS(BlueprintType, EditInlineNew, DefaultToInstanced, ClassGroup=(Interchange), meta=(DisplayName="VRM Spring Bones (Post-Import)"))
+class VRMINTERCHANGEEDITOR_API UVRMSpringBonesPostImportPipeline : public UInterchangePipelineBase
 {
     GENERATED_BODY()
 public:
+    UVRMSpringBonesPostImportPipeline() = default;
+
 #if WITH_EDITOR
-    // Visible toggle in Project Settings > Interchange > Pipelines
     UPROPERTY(EditAnywhere, Category = "VRM Spring")
     bool bGenerateSpringBoneData = false;
 
-    // Create or overwrite existing asset with same name
     UPROPERTY(EditAnywhere, Category = "VRM Spring")
     bool bOverwriteExisting = false;
 
-    // Folder suffix under the root imported package
     UPROPERTY(EditAnywhere, Category = "VRM Spring")
     FString SubFolder = TEXT("SpringBones");
 
-    // Base name of the data asset
     UPROPERTY(EditAnywhere, Category = "VRM Spring")
     FString DataAssetName = TEXT("SpringBonesData");
 #endif
@@ -39,16 +37,9 @@ public:
 
 private:
 #if WITH_EDITOR
-    // Parse and fill directly from source file (delegates JSON extraction to shared parser)
     bool ParseAndFillDataAssetFromFile(const FString& Filename, UVRMSpringBoneData* Dest) const;
-
-    // Use ContentBasePath when available; fallback to /Game/<VRMBaseName>
     FString MakeTargetPathAndName(const FString& SourceFilename, const FString& ContentBasePath, FString& OutPackagePath, FString& OutAssetName) const;
-
-    // Resolve BoneName from glTF node indices using cgltf (editor-only)
     bool ResolveBoneNamesFromFile(const FString& Filename, FVRMSpringConfig& InOut, int32& OutResolvedColliders, int32& OutResolvedJoints, int32& OutResolvedCenters) const;
-
-    // Validate resolved BoneNames against a USkeleton found under the imported asset's folder
     void ValidateBoneNamesAgainstSkeleton(const FString& SearchRootPackagePath, const FVRMSpringConfig& Config) const;
 #endif
 };

--- a/Plugins/VRMInterchange/Source/VRMInterchangeEditor/Public/FVRMInterchangeEditorModule.h
+++ b/Plugins/VRMInterchange/Source/VRMInterchangeEditor/Public/FVRMInterchangeEditorModule.h
@@ -1,0 +1,12 @@
+// In VRMInterchangeEditorModule.h
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Modules/ModuleInterface.h"
+
+class FVRMInterchangeEditorModule : public IModuleInterface
+{
+public:
+    virtual void StartupModule() override;
+    virtual void ShutdownModule() override;
+};

--- a/Plugins/VRMInterchange/Source/VRMInterchangeEditor/Public/VRMInterchangeSettings.h
+++ b/Plugins/VRMInterchange/Source/VRMInterchangeEditor/Public/VRMInterchangeSettings.h
@@ -4,11 +4,13 @@
 #include "Engine/DeveloperSettings.h"
 #include "VRMInterchangeSettings.generated.h"
 
-UCLASS(config=EditorPerProjectUserSettings, defaultconfig, meta=(DisplayName="VRM Interchange"))
+UCLASS(config=Game, defaultconfig, meta=(DisplayName="VRM Interchange"))
 class VRMINTERCHANGEEDITOR_API UVRMInterchangeSettings : public UDeveloperSettings
 {
     GENERATED_BODY()
 public:
+	UVRMInterchangeSettings();
+
     UPROPERTY(EditAnywhere, config, Category="Spring Bones", meta=(ToolTip="Parse and generate spring bone data assets during import."))
     bool bGenerateSpringBoneData = false;
 

--- a/Plugins/VRMInterchange/Source/VRMInterchangeEditor/VRMInterchangeEditor.build.cs
+++ b/Plugins/VRMInterchange/Source/VRMInterchangeEditor/VRMInterchangeEditor.build.cs
@@ -28,6 +28,7 @@ public class VRMInterchangeEditor : ModuleRules
             "InterchangeEditor",
             "InterchangeNodes",
             "InterchangeFactoryNodes",
+            "InterchangePipelines",  // Add this line
             "DeveloperSettings",
             // Asset authoring
             "AssetRegistry",

--- a/Plugins/VRMInterchange/VRMInterchange.uplugin
+++ b/Plugins/VRMInterchange/VRMInterchange.uplugin
@@ -9,12 +9,14 @@
     {
       "Name": "VRMInterchange",
       "Type": "Runtime",
-      "LoadingPhase": "Default"
+      "LoadingPhase": "Default",
+      "EnabledByDefault": true
     },
     {
       "Name": "VRMInterchangeEditor",
       "Type": "Editor",
-      "LoadingPhase": "Default"
+      "LoadingPhase": "PreDefault",
+      "EnabledByDefault": true
     }
   ],
   "EnabledByDefault": true,


### PR DESCRIPTION
#### PR Classification  
New feature: Added support for parsing and generating spring bone data from VRM files, along with post-import processing and validation.  

#### PR Summary  
This PR introduces functionality to parse VRM spring bone data, generate corresponding assets, and validate them against skeletons during import. It also adds new settings, logging, and unit tests to ensure correctness.  
- **`VRMSpringBonesParser.cpp` and `VRMSpringBonesTypes.h`**: Added JSON parsing for VRM 0.x and VRM 1.0 spring bone data, including colliders, joints, and springs.  
- **`UVRMSpringBonesPostImportPipeline`**: Handles post-import processing, resolving bone names, validating against skeletons, and saving spring bone data assets.  
- **`UVRMSpringBoneData`**: Introduced a new data asset to store parsed spring bone configurations with provenance information.  
- **`VRMInterchangeSettings`**: Added plugin settings for enabling spring bone data generation and related options.  
- **Unit Tests**: Added tests in `VRMSpringBonesParserTests.cpp` and `VRMSpringBonesNameResolveTests.cpp` to validate parsing and name resolution.  
