### PR TITLE
Enhance VRM Spring Bone parsing and collision handling

### DIFF
--- a/Plugins/VRMInterchange/Source/VRMInterchange/Public/VRMSpringBoneData.h
+++ b/Plugins/VRMInterchange/Source/VRMInterchange/Public/VRMSpringBoneData.h
@@ -12,7 +12,8 @@ class VRMINTERCHANGE_API UVRMSpringBoneData : public UDataAsset
 {
     GENERATED_BODY()
 public:
-    UPROPERTY(EditAnywhere, Category="Spring Bones")
+    // Show inner struct fields directly so users can inspect arrays like Colliders/Joints/Springs
+    UPROPERTY(EditAnywhere, Category="Spring Bones", meta=(ShowOnlyInnerProperties))
     FVRMSpringConfig SpringConfig;
 
     UPROPERTY(VisibleAnywhere, Category="Spring Bones")

--- a/Plugins/VRMInterchange/Source/VRMInterchange/Public/VRMSpringBonesTypes.h
+++ b/Plugins/VRMInterchange/Source/VRMInterchange/Public/VRMSpringBonesTypes.h
@@ -3,7 +3,7 @@
 #include "CoreMinimal.h"
 #include "VRMSpringBonesTypes.generated.h"
 
-UENUM()
+UENUM(BlueprintType)
 enum class EVRMSpringSpec : uint8
 {
     None,
@@ -11,103 +11,103 @@ enum class EVRMSpringSpec : uint8
     VRM1
 };
 
-USTRUCT()
+USTRUCT(BlueprintType)
 struct VRMINTERCHANGE_API FVRMSpringColliderSphere
 {
     GENERATED_BODY()
 
-    UPROPERTY() FVector Offset = FVector::ZeroVector;
-    UPROPERTY() float Radius = 0.f;
+    UPROPERTY(VisibleAnywhere, Category="VRM") FVector Offset = FVector::ZeroVector;
+    UPROPERTY(VisibleAnywhere, Category="VRM") float Radius = 0.f;
 };
 
-USTRUCT()
+USTRUCT(BlueprintType)
 struct VRMINTERCHANGE_API FVRMSpringColliderCapsule
 {
     GENERATED_BODY()
 
-    UPROPERTY() FVector Offset = FVector::ZeroVector;
-    UPROPERTY() float Radius = 0.f;
-    UPROPERTY() FVector TailOffset = FVector::ZeroVector;
+    UPROPERTY(VisibleAnywhere, Category="VRM") FVector Offset = FVector::ZeroVector;
+    UPROPERTY(VisibleAnywhere, Category="VRM") float Radius = 0.f;
+    UPROPERTY(VisibleAnywhere, Category="VRM") FVector TailOffset = FVector::ZeroVector;
 };
 
-USTRUCT()
+USTRUCT(BlueprintType)
 struct VRMINTERCHANGE_API FVRMSpringCollider
 {
     GENERATED_BODY()
 
     // Node index in glTF (if known)
-    UPROPERTY() int32 NodeIndex = INDEX_NONE;
+    UPROPERTY(VisibleAnywhere, Category="VRM") int32 NodeIndex = INDEX_NONE;
     // Optional bone name resolved later
-    UPROPERTY() FName BoneName;
+    UPROPERTY(VisibleAnywhere, Category="VRM") FName BoneName;
 
     // Shapes (VRM1 supports multiple shapes per collider)
-    UPROPERTY() TArray<FVRMSpringColliderSphere> Spheres;
-    UPROPERTY() TArray<FVRMSpringColliderCapsule> Capsules;
+    UPROPERTY(VisibleAnywhere, Category="VRM") TArray<FVRMSpringColliderSphere> Spheres;
+    UPROPERTY(VisibleAnywhere, Category="VRM") TArray<FVRMSpringColliderCapsule> Capsules;
 };
 
-USTRUCT()
+USTRUCT(BlueprintType)
 struct VRMINTERCHANGE_API FVRMSpringColliderGroup
 {
     GENERATED_BODY()
 
-    UPROPERTY() FString Name;
+    UPROPERTY(VisibleAnywhere, Category="VRM") FString Name;
     // Indices into Colliders array
-    UPROPERTY() TArray<int32> ColliderIndices;
+    UPROPERTY(VisibleAnywhere, Category="VRM") TArray<int32> ColliderIndices;
 };
 
-USTRUCT()
+USTRUCT(BlueprintType)
 struct VRMINTERCHANGE_API FVRMSpringJoint
 {
     GENERATED_BODY()
 
     // Node index in glTF (if known)
-    UPROPERTY() int32 NodeIndex = INDEX_NONE;
+    UPROPERTY(VisibleAnywhere, Category="VRM") int32 NodeIndex = INDEX_NONE;
     // Optional bone name resolved later
-    UPROPERTY() FName BoneName;
+    UPROPERTY(VisibleAnywhere, Category="VRM") FName BoneName;
 
     // Per-joint params (normalized)
-    UPROPERTY() float HitRadius = 0.f;
+    UPROPERTY(VisibleAnywhere, Category="VRM") float HitRadius = 0.f;
 };
 
-USTRUCT()
+USTRUCT(BlueprintType)
 struct VRMINTERCHANGE_API FVRMSpring
 {
     GENERATED_BODY()
 
-    UPROPERTY() FString Name;
+    UPROPERTY(VisibleAnywhere, Category="VRM") FString Name;
 
     // Joints composing this spring (indices into Joints)
-    UPROPERTY() TArray<int32> JointIndices;
+    UPROPERTY(VisibleAnywhere, Category="VRM") TArray<int32> JointIndices;
 
     // Groups referenced by this spring (indices into ColliderGroups)
-    UPROPERTY() TArray<int32> ColliderGroupIndices;
+    UPROPERTY(VisibleAnywhere, Category="VRM") TArray<int32> ColliderGroupIndices;
 
     // Optional center (node index if known)
-    UPROPERTY() int32 CenterNodeIndex = INDEX_NONE;
-    UPROPERTY() FName CenterBoneName;
+    UPROPERTY(VisibleAnywhere, Category="VRM") int32 CenterNodeIndex = INDEX_NONE;
+    UPROPERTY(VisibleAnywhere, Category="VRM") FName CenterBoneName;
 
     // Spring parameters
-    UPROPERTY() float Stiffness = 0.f;
-    UPROPERTY() float Drag = 0.f;
-    UPROPERTY() FVector GravityDir = FVector(0, 0, -1);
-    UPROPERTY() float GravityPower = 0.f;
-    UPROPERTY() float HitRadius = 0.f;
+    UPROPERTY(VisibleAnywhere, Category="VRM") float Stiffness = 0.f;
+    UPROPERTY(VisibleAnywhere, Category="VRM") float Drag = 0.f;
+    UPROPERTY(VisibleAnywhere, Category="VRM") FVector GravityDir = FVector(0, 0, -1);
+    UPROPERTY(VisibleAnywhere, Category="VRM") float GravityPower = 0.f;
+    UPROPERTY(VisibleAnywhere, Category="VRM") float HitRadius = 0.f;
 };
 
-USTRUCT()
+USTRUCT(BlueprintType)
 struct VRMINTERCHANGE_API FVRMSpringConfig
 {
     GENERATED_BODY()
 
-    UPROPERTY() EVRMSpringSpec Spec = EVRMSpringSpec::None;
+    UPROPERTY(VisibleAnywhere, Category="VRM") EVRMSpringSpec Spec = EVRMSpringSpec::None;
 
-    UPROPERTY() TArray<FVRMSpringCollider> Colliders;
-    UPROPERTY() TArray<FVRMSpringColliderGroup> ColliderGroups;
-    UPROPERTY() TArray<FVRMSpringJoint> Joints; // Mainly for VRM1
-    UPROPERTY() TArray<FVRMSpring> Springs;
+    UPROPERTY(VisibleAnywhere, Category="VRM") TArray<FVRMSpringCollider> Colliders;
+    UPROPERTY(VisibleAnywhere, Category="VRM") TArray<FVRMSpringColliderGroup> ColliderGroups;
+    UPROPERTY(VisibleAnywhere, Category="VRM") TArray<FVRMSpringJoint> Joints; // Mainly for VRM1
+    UPROPERTY(VisibleAnywhere, Category="VRM") TArray<FVRMSpring> Springs;
 
     // Optional raw JSON copy for diagnostics
-    UPROPERTY() FString RawJson;
+    UPROPERTY(VisibleAnywhere, Category="VRM") FString RawJson;
 
     bool IsValid() const
     {

--- a/Plugins/VRMInterchange/Source/VRMInterchangeEditor/Private/VRMInterchangeSettings.cpp
+++ b/Plugins/VRMInterchange/Source/VRMInterchangeEditor/Private/VRMInterchangeSettings.cpp
@@ -11,4 +11,7 @@ UVRMInterchangeSettings::UVRMInterchangeSettings()
 	bGeneratePostProcessAnimBP = false;
 	bAssignPostProcessABP = false;
 	bOverwriteExistingSpringAssets = false;
+	bOverwriteExistingPostProcessABP = false;
+	// New default: prefer reusing existing ABP on re-import
+	bReusePostProcessABPOnReimport = true;
 }

--- a/Plugins/VRMInterchange/Source/VRMInterchangeEditor/Private/VRMSpringBonesPostImportPipeline.h
+++ b/Plugins/VRMInterchange/Source/VRMInterchangeEditor/Private/VRMSpringBonesPostImportPipeline.h
@@ -35,6 +35,14 @@ public:
     UPROPERTY(EditAnywhere, Category = "VRM Spring", meta=(DisplayName="Assign Post-Process AnimBP", ToolTip="Assign the duplicated Post-Process AnimBP to the imported SkeletalMesh."))
     bool bAssignPostProcessABP = false;
 
+    // New: control whether generated ABP should overwrite existing with same name
+    UPROPERTY(EditAnywhere, Category = "VRM Spring", meta=(DisplayName="Overwrite Post-Process AnimBP", ToolTip="If true, overwrite existing generated Post-Process AnimBlueprints. If false, create a unique name."))
+    bool bOverwriteExistingPostProcessABP = false;
+
+    // New: control whether to reuse existing ABP on re-import
+    UPROPERTY(EditAnywhere, Category = "VRM Spring", meta=(DisplayName="Reuse Post-Process ABP on Re-Import", ToolTip="If true, attempt to reuse an existing Post-Process AnimBP when re-importing. If false, prompt to overwrite or create new."))
+    bool bReusePostProcessABPOnReimport = true;
+
     UPROPERTY(EditAnywhere, Category = "VRM Spring", meta=(DisplayName="Animation Sub-Folder"))
     FString AnimationSubFolder = TEXT("Animation");
 
@@ -60,7 +68,7 @@ private:
 
     // Phase 3 helpers
     bool FindImportedSkeletalAssets(const FString& SearchRootPackagePath, USkeletalMesh*& OutSkeletalMesh, USkeleton*& OutSkeleton) const;
-    UObject* DuplicateTemplateAnimBlueprint(const FString& TargetPackagePath, const FString& BaseName, USkeleton* TargetSkeleton) const;
+    UObject* DuplicateTemplateAnimBlueprint(const FString& TargetPackagePath, const FString& BaseName, USkeleton* TargetSkeleton, bool bOverwriteExistingABP) const;
     bool SetSpringConfigOnAnimBlueprint(UObject* AnimBlueprintObj, UVRMSpringBoneData* SpringData) const;
     bool AssignPostProcessABPToMesh(USkeletalMesh* SkelMesh, UObject* AnimBlueprintObj) const;
 

--- a/Plugins/VRMInterchange/Source/VRMInterchangeEditor/Public/VRMInterchangeSettings.h
+++ b/Plugins/VRMInterchange/Source/VRMInterchangeEditor/Public/VRMInterchangeSettings.h
@@ -23,5 +23,13 @@ public:
     UPROPERTY(EditAnywhere, config, Category="Spring Bones", meta=(ToolTip="If true, overwrite existing generated spring assets. If false, create with a suffix."))
     bool bOverwriteExistingSpringAssets = false;
 
+    // New: separate control for overwriting generated Post-Process AnimBlueprints
+    UPROPERTY(EditAnywhere, config, Category="Spring Bones", meta=(ToolTip="If true, overwrite existing generated Post-Process AnimBlueprints. If false, create with a unique name."))
+    bool bOverwriteExistingPostProcessABP = false;
+
+    // New: control whether to reuse an existing Post-Process ABP on re-import (preferred safe default)
+    UPROPERTY(EditAnywhere, config, Category="Spring Bones", meta=(ToolTip="If true, attempt to reuse an existing Post-Process AnimBP when re-importing. If false, the importer will offer to overwrite or create a new ABP."))
+    bool bReusePostProcessABPOnReimport = true;
+
     virtual FName GetCategoryName() const override { return TEXT("Plugins"); }
 };

--- a/Plugins/VRMInterchange/Source/VRMSpringBonesRuntime/Private/Tests/VRMSpringBoneChainTests.cpp
+++ b/Plugins/VRMInterchange/Source/VRMSpringBonesRuntime/Private/Tests/VRMSpringBoneChainTests.cpp
@@ -55,4 +55,45 @@ bool FVRMSpringBoneChainResolutionTest::RunTest(const FString& Parameters)
     return true;
 }
 
+// Test: ComputeRestFromPositions should compute segment lengths and normalized directions from component-space positions
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FVRMSpringBoneRestFromPositionsTest, "VRM.SpringBones.RestFromPositions", EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+bool FVRMSpringBoneRestFromPositionsTest::RunTest(const FString& Parameters)
+{
+    FAnimNode_VRMSpringBone::FChainInfo Chain;
+
+    // Simple straight chain along X: (0,0,0) -> (10,0,0) -> (20,0,0)
+    Chain.RestComponentPositions = TArray<FVector>{ FVector::ZeroVector, FVector(10.f,0.f,0.f), FVector(20.f,0.f,0.f) };
+    FAnimNode_VRMSpringBone::ComputeRestFromPositions(Chain);
+    TestEqual(TEXT("Segments count"), Chain.SegmentRestLengths.Num(), 3);
+    TestTrue(TEXT("Segment 1 length"), FMath::IsNearlyEqual(Chain.SegmentRestLengths[1], 10.f, KINDA_SMALL_NUMBER));
+    TestTrue(TEXT("Segment 2 length"), FMath::IsNearlyEqual(Chain.SegmentRestLengths[2], 10.f, KINDA_SMALL_NUMBER));
+    TestTrue(TEXT("Direction unit X"), Chain.RestDirections[1].Equals(FVector(1.f,0.f,0.f), KINDA_SMALL_NUMBER) && Chain.RestDirections[2].Equals(FVector(1.f,0.f,0.f), KINDA_SMALL_NUMBER));
+
+    // Non-uniform positions: second segment has diagonal offset
+    Chain.RestComponentPositions = TArray<FVector>{ FVector::ZeroVector, FVector(10.f,0.f,0.f), FVector(20.f,10.f,0.f) };
+    FAnimNode_VRMSpringBone::ComputeRestFromPositions(Chain);
+    const float ExpectedLen2 = FVector(20.f,10.f,0.f).Size() - FVector(10.f,0.f,0.f).Size();
+    // Instead compute segment2 len directly
+    const float Seg2 = (FVector(20.f,10.f,0.f) - FVector(10.f,0.f,0.f)).Size();
+    TestTrue(TEXT("Segment 2 diagonal length"), FMath::IsNearlyEqual(Chain.SegmentRestLengths[2], Seg2, KINDA_SMALL_NUMBER));
+    FVector Dir2 = Chain.RestDirections[2];
+    FVector ExpectedDir2 = (FVector(20.f,10.f,0.f) - FVector(10.f,0.f,0.f)).GetSafeNormal();
+    TestTrue(TEXT("Segment 2 direction normalized"), Dir2.Equals(ExpectedDir2, KINDA_SMALL_NUMBER));
+
+    return true;
+}
+
+// Test: mirrored chain should produce directions with negative X when positions are mirrored
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FVRMSpringBoneMirroredRestDirectionsTest, "VRM.SpringBones.MirroredRestDirections", EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+bool FVRMSpringBoneMirroredRestDirectionsTest::RunTest(const FString& Parameters)
+{
+    FAnimNode_VRMSpringBone::FChainInfo Chain;
+    Chain.RestComponentPositions = TArray<FVector>{ FVector::ZeroVector, FVector(-10.f,0.f,0.f) };
+    FAnimNode_VRMSpringBone::ComputeRestFromPositions(Chain);
+    TestEqual(TEXT("Segments count"), Chain.SegmentRestLengths.Num(), 2);
+    TestTrue(TEXT("Mirrored direction X"), Chain.RestDirections[1].Equals(FVector(-1.f,0.f,0.f), KINDA_SMALL_NUMBER));
+    TestTrue(TEXT("Mirrored length"), FMath::IsNearlyEqual(Chain.SegmentRestLengths[1], 10.f, KINDA_SMALL_NUMBER));
+    return true;
+}
+
 #endif // WITH_DEV_AUTOMATION_TESTS

--- a/Plugins/VRMInterchange/Source/VRMSpringBonesRuntime/Public/AnimNode_VRMSpringBone.h
+++ b/Plugins/VRMInterchange/Source/VRMSpringBonesRuntime/Public/AnimNode_VRMSpringBone.h
@@ -59,6 +59,23 @@ public:
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Spring")
     bool bForceReset = false;
 
+    // Unit conversion for VRM radii (VRM is meters, UE is centimeters)
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Collision")
+    bool bVRMRadiiInMeters = true;
+
+    // Scale applied to VRM radii values when bVRMRadiiInMeters is true (default 100 cm/m)
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Collision", meta=(EditCondition="bVRMRadiiInMeters", ClampMin="0.1", ClampMax="1000"))
+    float VRMToCentimetersScale = 100.f;
+
+    // Collision response tuning
+    // Tangential velocity retained after collision: 0 = no friction (retain full tangent), 1 = full stop of tangent
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Collision", meta=(ClampMin="0", ClampMax="1"))
+    float CollisionFriction = 0.2f;
+
+    // Elasticity along collision normal: 0 = absorb (no bounce), 1 = reflect full normal velocity
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Collision", meta=(ClampMin="0", ClampMax="1"))
+    float CollisionRestitution = 0.0f;
+
     struct FChainInfo
     {
             // Resolved bones
@@ -81,6 +98,8 @@ public:
             FName  CenterBoneName;                        // optional
             FCompactPoseBoneIndex CenterCompactIndex = FCompactPoseBoneIndex(INDEX_NONE);
             float  CenterPullStrength = 0.f;              // 0 disables
+            // Per-joint radii (from joint entries) — matches CompactIndices ordering
+            TArray<float> JointHitRadii;
             // Stats
             int32 IntendedJointCount = 0;
             int32 MissingJointCount = 0;
@@ -100,6 +119,10 @@ public:
     // Test helper: compute rest data for a chain from a supplied reference skeleton (no BoneContainer needed)
     static void ComputeRestFromReferenceSkeleton(const struct FReferenceSkeleton& RefSkel, FChainInfo& Chain);
     static void ComputeRestFromPositions(FChainInfo& Chain);
+
+    // Lightweight math helpers exposed for tests
+    static FVector ProjectPointOnSegment(const FVector& A, const FVector& B, const FVector& P);
+    static void ResolveCapsuleCollisionTestHook(FVector& JointPos, FVector& PrevPos, const FVector& A, const FVector& B, float CapsuleRadius, float JointRadius, float Friction, float Restitution);
 
 private:
     void BuildChains(const FBoneContainer& BoneContainer);


### PR DESCRIPTION
Enhance VRM Spring Bone parsing and collision handling

- Added helper functions (`ParseOneShapeObject`, `BuildNodeColliderShapeMap`) to improve flexibility in parsing collider shapes.
- Enhanced collision handling in `AnimNode_VRMSpringBone` with support for sphere and capsule collisions, including friction and restitution.
- Improved debug visualization to include colliders in simulation.
- Exposed VRM spring-related structs to Blueprints for better editor integration.
- Added unit conversion for VRM radii (meters to centimeters).
- Introduced settings for reusing and overwriting animation blueprints during re-import.
- Enhanced chain initialization to recompute rest lengths and directions dynamically.
- Added automation tests for spring bone chain validation.
- Refactored `DuplicateTemplateAnimBlueprint` to support overwriting existing ABPs.
- Improved logging, documentation, and formatting for better maintainability.