### PR TITLE
Add IK Rig Post-Import Pipeline for VRM assets

### DIFF
--- a/Plugins/VRMInterchange/Content/Animation/IK_Rig_VRMTemplate.uasset
+++ b/Plugins/VRMInterchange/Content/Animation/IK_Rig_VRMTemplate.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1e8be3f5de2d731f2ea21f0ebd769f09a5fdcb92ab382c5a8aafe390f835c40c
+size 102447

--- a/Plugins/VRMInterchange/Content/DefaultPipelines/DefaultVRMIKRigPipeline.uasset
+++ b/Plugins/VRMInterchange/Content/DefaultPipelines/DefaultVRMIKRigPipeline.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1ee2b01ef849c7ba93523c7eeab93ba98da1f0c1aed75399679e7d883f4537dc
+size 1273

--- a/Plugins/VRMInterchange/Source/VRMInterchangeEditor/Private/VRMIKRigPostImportPipeline.cpp
+++ b/Plugins/VRMInterchange/Source/VRMInterchangeEditor/Private/VRMIKRigPostImportPipeline.cpp
@@ -1,0 +1,215 @@
+#include "VRMIKRigPostImportPipeline.h"
+
+#include "InterchangeSourceData.h"
+#include "Nodes/InterchangeBaseNodeContainer.h"
+#include "AssetRegistry/AssetRegistryModule.h"
+#include "AssetToolsModule.h"
+#include "IAssetTools.h"
+#include "Misc/PackageName.h"
+#include "Misc/Paths.h"
+#include "UObject/Package.h"
+#include "UObject/SavePackage.h"
+#include "Modules/ModuleManager.h"
+#include "Animation/Skeleton.h"
+#include "Engine/SkeletalMesh.h"
+#include "Rig/IKRigDefinition.h"
+
+void UVRMIKRigPostImportPipeline::ExecutePipeline(UInterchangeBaseNodeContainer* BaseNodeContainer, const TArray<UInterchangeSourceData*>& SourceDatas, const FString& ContentBasePath)
+{
+#if WITH_EDITOR
+	if (!BaseNodeContainer)
+	{
+		return;
+	}
+
+	const UInterchangeSourceData* Source = nullptr;
+	for (const UInterchangeSourceData* SD : SourceDatas)
+	{
+		if (SD) { Source = SD; break; }
+	}
+	if (!Source)
+	{
+		return;
+	}
+
+	const FString Filename = Source->GetFilename();
+
+	// Character base path: /Game/<CharacterName>
+	const FString CharacterBasePath = MakeCharacterBasePath(Filename, ContentBasePath);
+	DeferredPackagePath = CharacterBasePath;
+	const FString AnimFolder = CharacterBasePath / AnimationSubFolder;
+	const FString CharacterName = FPaths::GetBaseFilename(Filename);
+	const FString DesiredIKName = FString::Printf(TEXT("IK_Rig_VRM_%s"), *CharacterName);
+
+	USkeletalMesh* SkelMesh=nullptr; USkeleton* Skeleton=nullptr;
+	const bool bFoundHere = FindImportedSkeletalAssets(CharacterBasePath, SkelMesh, Skeleton) && (SkelMesh || Skeleton);
+	const bool bFoundParent = !bFoundHere && FindImportedSkeletalAssets(GetParentPackagePath(CharacterBasePath), SkelMesh, Skeleton) && (SkelMesh || Skeleton);
+	if (!bFoundHere && !bFoundParent)
+	{
+		// No skeletal assets yet - register for deferral
+		RegisterDeferredIKRig(CharacterBasePath, CharacterBasePath);
+		DeferredAltSkeletonSearchRoot = GetParentPackagePath(CharacterBasePath);
+		return;
+	}
+
+	UIKRigDefinition* NewIKRig = nullptr;
+	if (!DuplicateTemplateIKRig(AnimFolder, DesiredIKName, NewIKRig, bOverwriteExisting))
+	{
+		return;
+	}
+
+	if (NewIKRig)
+	{
+		USkeletalMesh* TargetMesh = SkelMesh;
+		if (!TargetMesh && Skeleton)
+		{
+			// best effort: find any mesh using this skeleton under character
+			FAssetRegistryModule& ARM = FModuleManager::LoadModuleChecked<FAssetRegistryModule>("AssetRegistry");
+			FARFilter MeshFilter; MeshFilter.bRecursivePaths=true; MeshFilter.PackagePaths.Add(*CharacterBasePath); MeshFilter.ClassPaths.Add(USkeletalMesh::StaticClass()->GetClassPathName());
+			TArray<FAssetData> Meshes; ARM.Get().GetAssets(MeshFilter, Meshes);
+			if (Meshes.Num()>0) { TargetMesh = Cast<USkeletalMesh>(Meshes[0].GetAsset()); }
+		}
+
+		if (TargetMesh)
+		{
+			NewIKRig->SetPreviewMesh(TargetMesh, true);
+			NewIKRig->MarkPackageDirty();
+			if (UPackage* Pkg = NewIKRig->GetOutermost())
+			{
+				const FString FN = FPackageName::LongPackageNameToFilename(Pkg->GetName(), FPackageName::GetAssetPackageExtension());
+				FSavePackageArgs SaveArgs; SaveArgs.TopLevelFlags = RF_Public | RF_Standalone; SaveArgs.SaveFlags = SAVE_NoError;
+				UPackage::SavePackage(Pkg, nullptr, *FN, SaveArgs);
+			}
+		}
+	}
+#endif
+}
+
+#if WITH_EDITOR
+
+bool UVRMIKRigPostImportPipeline::FindImportedSkeletalAssets(const FString& SearchRootPackagePath, USkeletalMesh*& OutSkeletalMesh, USkeleton*& OutSkeleton) const
+{
+	OutSkeletalMesh=nullptr; OutSkeleton=nullptr; if(SearchRootPackagePath.IsEmpty()) return false; FAssetRegistryModule& ARM=FModuleManager::LoadModuleChecked<FAssetRegistryModule>("AssetRegistry");
+	FARFilter MeshFilter; MeshFilter.bRecursivePaths=true; MeshFilter.PackagePaths.Add(*SearchRootPackagePath); MeshFilter.ClassPaths.Add(USkeletalMesh::StaticClass()->GetClassPathName());
+	TArray<FAssetData> Meshes; ARM.Get().GetAssets(MeshFilter, Meshes);
+	if (Meshes.Num()>0){ OutSkeletalMesh=Cast<USkeletalMesh>(Meshes[0].GetAsset()); if(OutSkeletalMesh) OutSkeleton=OutSkeletalMesh->GetSkeleton(); }
+	if(!OutSkeleton){ FARFilter SkelFilter; SkelFilter.bRecursivePaths=true; SkelFilter.PackagePaths.Add(*SearchRootPackagePath); SkelFilter.ClassPaths.Add(USkeleton::StaticClass()->GetClassPathName()); TArray<FAssetData> Skels; ARM.Get().GetAssets(SkelFilter, Skels); if(Skels.Num()>0) OutSkeleton=Cast<USkeleton>(Skels[0].GetAsset()); }
+	return (OutSkeletalMesh!=nullptr)||(OutSkeleton!=nullptr);
+}
+
+FString UVRMIKRigPostImportPipeline::GetParentPackagePath(const FString& InPath) const
+{
+	int32 SlashIdx=INDEX_NONE; return (InPath.FindLastChar(TEXT('/'),SlashIdx)&&SlashIdx>1)?InPath.Left(SlashIdx):InPath;
+}
+
+FString UVRMIKRigPostImportPipeline::MakeCharacterBasePath(const FString& SourceFilename, const FString& ContentBasePath) const
+{
+	const FString BaseName = FPaths::GetBaseFilename(SourceFilename);
+	return !ContentBasePath.IsEmpty() ? (ContentBasePath / BaseName) : FString::Printf(TEXT("/Game/%s"), *BaseName);
+}
+
+bool UVRMIKRigPostImportPipeline::DuplicateTemplateIKRig(const FString& TargetPackagePath, const FString& BaseName, UIKRigDefinition*& OutIKRig, bool bOverwrite) const
+{
+	OutIKRig = nullptr;
+	// Load template in plugin
+	const TCHAR* TemplatePath = TEXT("/VRMInterchange/Animation/IK_Rig_VRMTemplate.IK_Rig_VRMTemplate");
+	UIKRigDefinition* TemplateRig = Cast<UIKRigDefinition>(StaticLoadObject(UIKRigDefinition::StaticClass(), nullptr, TemplatePath));
+	if (!TemplateRig)
+	{
+		UE_LOG(LogTemp, Warning, TEXT("[VRMInterchange] IK Rig pipeline: Could not find template IK Rig at '%s'."), TemplatePath);
+		return false;
+	}
+
+	FString NewAssetPath = TargetPackagePath / BaseName;
+	FAssetToolsModule& AssetToolsModule=FModuleManager::LoadModuleChecked<FAssetToolsModule>("AssetTools");
+	FString UniquePath, UniqueName;
+	if (!bOverwrite)
+	{
+		AssetToolsModule.Get().CreateUniqueAssetName(NewAssetPath, TEXT(""), UniquePath, UniqueName);
+	}
+	else
+	{
+		UniquePath = NewAssetPath;
+		UniqueName = BaseName;
+	}
+
+	const FString LongPackage = UniquePath.StartsWith(TEXT("/")) ? UniquePath : TEXT("/") + UniquePath;
+	UPackage* Pkg = CreatePackage(*LongPackage);
+	if (!Pkg) return false;
+
+	UObject* Duplicated = StaticDuplicateObject(TemplateRig, Pkg, *UniqueName);
+	if (!Duplicated) { UE_LOG(LogTemp, Warning, TEXT("[VRMInterchange] IK Rig pipeline: Failed to duplicate template IK Rig.")); return false; }
+	FAssetRegistryModule::AssetCreated(Duplicated);
+	OutIKRig = Cast<UIKRigDefinition>(Duplicated);
+	return OutIKRig != nullptr;
+}
+
+void UVRMIKRigPostImportPipeline::RegisterDeferredIKRig(const FString& InSkeletonSearchRoot, const FString& InPackagePath)
+{
+	UnregisterDeferredIKRig();
+	DeferredSkeletonSearchRoot = InSkeletonSearchRoot;
+	DeferredAltSkeletonSearchRoot = GetParentPackagePath(InSkeletonSearchRoot);
+	DeferredPackagePath = InPackagePath;
+	bDeferredCompleted = false;
+	FAssetRegistryModule& ARM=FModuleManager::LoadModuleChecked<FAssetRegistryModule>("AssetRegistry");
+	DeferredHandle = ARM.Get().OnAssetAdded().AddUObject(this, &UVRMIKRigPostImportPipeline::OnAssetAddedForDeferredIKRig);
+}
+
+void UVRMIKRigPostImportPipeline::UnregisterDeferredIKRig()
+{
+	if (DeferredHandle.IsValid())
+	{
+		if (FModuleManager::Get().IsModuleLoaded("AssetRegistry"))
+		{
+			FAssetRegistryModule& ARM = FModuleManager::GetModuleChecked<FAssetRegistryModule>("AssetRegistry");
+			ARM.Get().OnAssetAdded().Remove(DeferredHandle);
+		}
+		DeferredHandle.Reset();
+	}
+}
+
+void UVRMIKRigPostImportPipeline::OnAssetAddedForDeferredIKRig(const FAssetData& AssetData)
+{
+	if (bDeferredCompleted || !AssetData.IsValid()) return;
+	const FName ClassName = AssetData.AssetClassPath.GetAssetName();
+	const bool bIsSkeletalMesh = (ClassName == USkeletalMesh::StaticClass()->GetFName());
+	const bool bIsSkeleton = (ClassName == USkeleton::StaticClass()->GetFName());
+	if (!bIsSkeletalMesh && !bIsSkeleton) return;
+
+	const FString PkgPath = AssetData.PackagePath.ToString();
+	if (!PkgPath.StartsWith(DeferredSkeletonSearchRoot) && !PkgPath.StartsWith(DeferredAltSkeletonSearchRoot)) return;
+
+	USkeletalMesh* SkelMesh=nullptr; USkeleton* Skeleton=nullptr;
+	bool bFound = FindImportedSkeletalAssets(DeferredSkeletonSearchRoot, SkelMesh, Skeleton) && (SkelMesh || Skeleton);
+	if (!bFound) bFound = FindImportedSkeletalAssets(DeferredAltSkeletonSearchRoot, SkelMesh, Skeleton) && (SkelMesh || Skeleton);
+	if (!bFound) return;
+
+	const FString CharacterName = FPaths::GetCleanFilename(DeferredPackagePath);
+	const FString DesiredIKName = FString::Printf(TEXT("IK_Rig_VRM_%s"), *CharacterName);
+
+	const FString AnimFolder = DeferredPackagePath / AnimationSubFolder;
+	UIKRigDefinition* NewIKRig = nullptr;
+	if (!DuplicateTemplateIKRig(AnimFolder, DesiredIKName, NewIKRig, bOverwriteExisting))
+	{
+		UnregisterDeferredIKRig();
+		bDeferredCompleted = true;
+		return;
+	}
+
+	if (NewIKRig && SkelMesh)
+	{
+		NewIKRig->SetPreviewMesh(SkelMesh, true);
+		NewIKRig->MarkPackageDirty();
+		if (UPackage* Pkg = NewIKRig->GetOutermost())
+		{
+			const FString FN = FPackageName::LongPackageNameToFilename(Pkg->GetName(), FPackageName::GetAssetPackageExtension());
+			FSavePackageArgs SaveArgs; SaveArgs.TopLevelFlags = RF_Public | RF_Standalone; SaveArgs.SaveFlags = SAVE_NoError;
+			UPackage::SavePackage(Pkg, nullptr, *FN, SaveArgs);
+		}
+	}
+
+	UnregisterDeferredIKRig();
+	bDeferredCompleted = true;
+}
+
+#endif

--- a/Plugins/VRMInterchange/Source/VRMInterchangeEditor/Private/VRMIKRigPostImportPipeline.h
+++ b/Plugins/VRMInterchange/Source/VRMInterchangeEditor/Private/VRMIKRigPostImportPipeline.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "InterchangePipelineBase.h"
+#include "VRMIKRigPostImportPipeline.generated.h"
+
+class UInterchangeBaseNodeContainer;
+class UInterchangeSourceData;
+class USkeletalMesh;
+class USkeleton;
+class UIKRigDefinition;
+
+UCLASS(BlueprintType, EditInlineNew, DefaultToInstanced, ClassGroup=(Interchange), meta=(DisplayName="VRM IK Rig (Post-Import)"))
+class VRMINTERCHANGEEDITOR_API UVRMIKRigPostImportPipeline : public UInterchangePipelineBase
+{
+	GENERATED_BODY()
+public:
+	UVRMIKRigPostImportPipeline() = default;
+
+#if WITH_EDITOR
+	// Whether to generate an IK Rig asset next to the imported mesh
+	UPROPERTY(EditAnywhere, Category = "VRM IK Rig")
+	bool bGenerateIKRig = true;
+
+	// Overwrite existing asset with same name
+	UPROPERTY(EditAnywhere, Category = "VRM IK Rig")
+	bool bOverwriteExisting = false;
+
+	// Subfolder under character folder to place the asset
+	UPROPERTY(EditAnywhere, Category = "VRM IK Rig")
+	FString AnimationSubFolder = TEXT("Animation");
+
+	// Base name of the generated asset
+	UPROPERTY(EditAnywhere, Category = "VRM IK Rig")
+	FString AssetBaseName = TEXT("IK_Rig_VRM");
+#endif
+
+	// UInterchangePipelineBase
+	virtual void ExecutePipeline(UInterchangeBaseNodeContainer* BaseNodeContainer, const TArray<UInterchangeSourceData*>& SourceDatas, const FString& ContentBasePath) override;
+
+private:
+#if WITH_EDITOR
+	bool FindImportedSkeletalAssets(const FString& SearchRootPackagePath, USkeletalMesh*& OutSkeletalMesh, USkeleton*& OutSkeleton) const;
+	FString GetParentPackagePath(const FString& InPath) const;
+	bool DuplicateTemplateIKRig(const FString& TargetPackagePath, const FString& BaseName, UIKRigDefinition*& OutIKRig, bool bOverwrite) const;
+	FString MakeCharacterBasePath(const FString& SourceFilename, const FString& ContentBasePath) const;
+
+	// Deferred creation if skeletal assets are not available yet
+	void RegisterDeferredIKRig(const FString& InSkeletonSearchRoot, const FString& InPackagePath);
+	void UnregisterDeferredIKRig();
+	void OnAssetAddedForDeferredIKRig(const struct FAssetData& AssetData);
+
+	// Deferred state
+	FDelegateHandle DeferredHandle;
+	FString DeferredSkeletonSearchRoot;
+	FString DeferredAltSkeletonSearchRoot;
+	FString DeferredPackagePath; // character base path
+	bool bDeferredCompleted = false;
+#endif
+};

--- a/Plugins/VRMInterchange/Source/VRMInterchangeEditor/VRMInterchangeEditor.build.cs
+++ b/Plugins/VRMInterchange/Source/VRMInterchangeEditor/VRMInterchangeEditor.build.cs
@@ -42,6 +42,9 @@ public class VRMInterchangeEditor : ModuleRules
 
             // Runtime plugin module this editor module depends on
             "VRMInterchange",
+
+            // For IKRigDefinition asset
+            "IKRig",
         });
 
         // We share some includes with the runtime module (optional)


### PR DESCRIPTION
Add IK Rig Post-Import Pipeline for VRM assets

Introduced `UVRMIKRigPostImportPipeline` to automate the creation of IK Rig assets for VRM skeletal meshes. The pipeline duplicates a template IK Rig (`IK_Rig_VRMTemplate`) and associates it with the imported skeletal mesh. Added support for deferred asset creation when skeletal assets are unavailable during import.

Updated the Spring Bones pipeline to include character-specific naming for generated animation blueprints (e.g., `ABP_VRMSpringBones_<CharacterName>`).

Integrated the IK Rig pipeline into the VRM Interchange Editor module, ensuring it is appended to default import pipelines. Added a dependency on the `IKRig` module in the build configuration.

Improved modularity, reusability, and error handling across pipelines, with better asset path management and logging.