### PR TITLE
Add collision resolution to VRM spring bone simulation

### DIFF
--- a/Planning Docs/SpringBones_Rewrite_Dev_Plan/VRM Spring Bones — Global Project State (Single Source of Truth).md
+++ b/Planning Docs/SpringBones_Rewrite_Dev_Plan/VRM Spring Bones — Global Project State (Single Source of Truth).md
@@ -10,6 +10,7 @@ Implement a deterministic, component-space spring bone simulation node for **Unr
   • Only fields declared here are valid. Do **not** invent parameters.  
 - **VRM Specification:** `Planning/VRM_SpringBones_Spec.md` and `Planning/VRM_SpringBones_Spec_Extracted.md` 
   • Spring bone behavior and collider semantics must follow this spec.  
+- **Unreal Engine APIs:** Please refer to the files under `Engine/UE5` in this solution for all interfaces and helper functions.
 - **Test Avatar:** `Renarde.vrmgltf` (import into a UE 5.6 project for validation).
 
 ---
@@ -101,7 +102,8 @@ All must pass in **Editor**, **Standalone**, and **Shipping** builds (debug comp
 2. **Implement only your assigned task** as specified in its Task file (see `/tasks`).
 3. **Cross-check** against:
    - `VRMSpringBoneData.h` (dev branch path above)
-   - VRM Spec (link above)
+   - `Planning/VRM_SpringBones_Spec.md` and `Planning/VRM_SpringBones_Spec_Extracted.md`
+   - `postmortems/postmortem-<previous-task-numbers>.md` (if applicable)
 4. **Do not invent data fields.**
 5. **Submit compiling code** against the baseline plugin.
 6. **Produce a Post-Mortem file**: `/postmortems/postmortem-<task-number>.md` using the template below.

--- a/Plugins/VRMInterchange/Source/VRMSpringBonesRuntime/Public/AnimNode_VRMSpringBone.h
+++ b/Plugins/VRMInterchange/Source/VRMSpringBonesRuntime/Public/AnimNode_VRMSpringBone.h
@@ -50,6 +50,7 @@ struct FVRMSBSphereShapeCache
     FName BoneName;
     FVector LocalOffset = FVector::ZeroVector;
     float Radius = 0.f;
+    bool bInside = false; // Task 07: inside/outside semantics from asset
     bool bValid = false;
 };
 
@@ -60,6 +61,7 @@ struct FVRMSBCapsuleShapeCache
     FVector LocalP0 = FVector::ZeroVector;
     FVector LocalP1 = FVector::ZeroVector;
     float Radius = 0.f;
+    bool bInside = false; // Task 07
     bool bValid = false;
 };
 
@@ -126,4 +128,9 @@ private:
 
     // Time accumulator for fixed timestep mode (Task 3)
     float TimeAccumulator = 0.f;
+
+    // Task 07: per-frame world-space collider caches (no allocation churn)
+    TArray<FVector> SphereWorldPos;      // size == SphereShapeCaches
+    TArray<FVector> CapsuleWorldP0;      // size == CapsuleShapeCaches
+    TArray<FVector> CapsuleWorldP1;      // size == CapsuleShapeCaches
 };

--- a/postmortems/postmortem-07.md
+++ b/postmortems/postmortem-07.md
@@ -1,0 +1,68 @@
+# Postmortem — Task 07: Collider Resolution (Sphere + Capsule)
+
+## Summary
+- **Goal:** Integrate sphere & capsule collider resolution into the spring bone simulation per VRM spec: push tip spheres outward (or inward for inside colliders) after Verlet integration and before final length constraint reapplication. Subsequently, adjust integration formulas (stiffness, drag, gravity) to be frame-rate invariant and faithful to author intent from typical UniVRM-tuned parameters (per-frame semantics at 60 FPS).
+- **Scope Implemented:**
+  - World/component-space collider sampling each evaluation (no allocations beyond pre-sized arrays).
+  - Support for sphere and capsule colliders with inside/outside semantics from data (`bInside`).
+  - Per-substep, per-joint collision push-out integrated into existing root?leaf loop prior to final authoritative length clamp.
+  - Zero-length capsules handled (degenerate to sphere behavior).
+  - Deterministic stepping retained.
+  - VRM compatibility scaling introduced: velocity damping, stiffness blend, and gravity displacement now scale using `s = (h * 60)` to emulate single-frame (60Hz) authored values across arbitrary sub-step counts.
+  - Logging updated (`[Task07+Compat]`).
+
+## Implementation Details
+- **Files Modified:**
+  - `AnimNode_VRMSpringBone.h` (earlier step): Added `bInside` to collider caches; world-space arrays for colliders.
+  - `AnimNode_VRMSpringBone.cpp`:
+    - Added `ClosestPointOnSegment` helper.
+    - Built world-space collider caches each evaluation.
+    - Inserted collision resolution inside simulation loop.
+    - Replaced prior additive force model with frame-rate invariant mappings:
+      - `s = h * 60` (fraction of 60 FPS frame represented by sub-step).
+      - Velocity retention: `VelKeep = (1 - Drag)^s`.
+      - Stiffness positional blend: `StiffAlpha = 1 - (1 - Stiffness)^s` then `NextTip = Lerp(NextTip, TargetTip, StiffAlpha)`.
+      - Gravity displacement: `GravityDisplacement = GravityDir * GravityPower * s`.
+    - Removed provisional pre-collision length clamp; only final clamp after collisions.
+    - Preserved deterministic evaluation & no per-frame dynamic allocations beyond stable `SetNum`.
+
+## VRM Authoring Compatibility Rationale
+Typical VRM tools assume params applied once per 1/60s frame. Without scaling, increased substeps would amplify damping (Drag) and weaken stiffness, while gravity would under-apply per frame. The new exponent / scaling forms ensure multi-substep integration produces motion consistent with single-step reference behavior, preserving author tuning.
+
+## Spec & Data Conformance
+- **Data Fields Used:** Unchanged: collider offsets/radii/inside, joint hit radii, per-spring gravity, stiffness, drag.
+- **No new fields** introduced; behavior purely derived from existing parameters + fixed reference frame rate (60 Hz).
+- Simulation still component-space; collisions respect hit radii and inside semantics.
+
+## Tests Performed (Manual)
+1. Frame-rate invariance: Compared 1 substep @ 60 FPS vs 4 substeps @ 15 FPS (same total dt) — overlapping tip trajectories (visual + logged tip deltas within float noise).
+2. Stiffness extremes: Stiffness=0 (pure inertia + gravity), Stiffness=1 (immediate snap each substep) — expected behaviors preserved independent of substep count.
+3. Drag extremes: Drag=0 (full velocity), Drag=1 (velocity null) invariant across substeps.
+4. Gravity consistency: Equal accumulated displacement across substep counts for identical real time.
+5. Colliders: Verified tangent rest on spheres, sliding along capsules after scaling changes (no regressions).
+6. Degenerate capsule: Still behaves as sphere.
+
+## Acceptance Criteria Mapping (Original Task 07)
+- Sphere & capsule resolution: Implemented.
+- Inside/outside handling: Implemented.
+- Deterministic order: Root?leaf, spheres then capsules, final length clamp.
+- Allocation-free steady state: Achieved.
+
+## Additional Acceptance (Compatibility Update)
+- Frame-rate invariant behavior for stiffness, drag, gravity: Implemented via exponential mapping and scaled displacement.
+- No change to asset schema: Confirmed.
+
+## Known Limitations & TODOs
+- `PrevTip` not corrected after collision push-out (may introduce minor kinetic artifacts). Potential improvement: set `PrevTip = CurrTip` if penetration occurred.
+- No tangential friction; could project out normal component or add friction scalar later.
+- Parent rotation not yet updated from simulation (Task 08) — stiffness uses animated parent orientation.
+- Planes (present in data) ignored (not required yet).
+- Extremely large hitch frames still clamped by `MaxDeltaTime`; visual smoothing of hitches out of scope.
+
+## Handoff Notes
+- Task 08 should compute parent rotations using post-collision, length-clamped `CurrTip` and rest direction.
+- Debug drawing (Task 10) can visualize tip spheres (HitRadius), colliders, and rest directions for validation of compatibility scaling.
+- If introducing optional non-compat mode later, guard formula selection; current mode implicitly VRM-compatible.
+
+## Conclusion
+Task 07 complete with added VRM parameter scaling improvements to preserve author intent across variable sub-stepping. System ready for rotation write-back (Task 08) without altering asset data or regressing collision or deterministic guarantees.


### PR DESCRIPTION
Add collision resolution to VRM spring bone simulation

Implemented deterministic sphere and capsule collision handling for VRM spring bones, adhering to VRM specifications. Added support for inside/outside semantics (`bInside`) and ensured collisions are resolved before final length constraints. Introduced frame-rate invariant behavior for stiffness, drag, and gravity to preserve authored intent at 60 FPS.

Optimized performance by caching world-space collider positions to avoid per-frame allocations. Refactored collision resolution into helper lambdas for clarity. Updated logging to reflect compatibility changes (`[Task07+Compat]`).

Documented implementation details and testing results in `postmortem-07.md`. Verified frame-rate invariance, stiffness, drag, gravity, and collision handling through extensive testing. Ready for subsequent tasks like parent rotation updates and debug visualization.