### PR TITLE
Add external velocity support to spring simulation

### DIFF
--- a/Plugins/VRMInterchange/Content/Animation/ABP_VRMSpringBones_Template.uasset
+++ b/Plugins/VRMInterchange/Content/Animation/ABP_VRMSpringBones_Template.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dc6672026f3c3ac57afdddda6738005b2956a11008f12c6532be5d7b6a39b2f4
-size 57286
+oid sha256:9da825c2a040b97783fe45494b2a60ae3c3d4d61a995bf7b754866a79a8c4f46
+size 107669

--- a/Plugins/VRMInterchange/Source/VRMSpringBonesRuntime/Private/AnimNode_VRMSpringBones.cpp
+++ b/Plugins/VRMInterchange/Source/VRMSpringBonesRuntime/Private/AnimNode_VRMSpringBones.cpp
@@ -288,6 +288,7 @@ void FAnimNode_VRMSpringBones::SimulateSpringsOnce(const FComponentSpacePoseCont
 		const bool  bHasColliders  = Spring.ColliderGroupIndices.Num() > 0;
 		const FVector GravityDir   = Spring.GravityDir;
 		const float DefaultHitRadius = FMath::Max(0.f, Spring.HitRadius * 100.0f);
+		const FVector ExternalVel	= ExternalVelocity * ExternalVelocityScale * DeltaTime;
 
 		for (int32 ChainPos = 0; ChainPos < SpringChainRng.Num; ++ChainPos)
 		{
@@ -321,7 +322,7 @@ void FAnimNode_VRMSpringBones::SimulateSpringsOnce(const FComponentSpacePoseCont
 			const FQuat AnimatedBoneRotCS = JointBoneCS.GetRotation();
 			const FVector RestTargetCS = CurrentHeadPosCS + AnimatedBoneRotCS.RotateVector(JointState.InitialLocalChildPos);
 
-			FVector SimTailPos = JointState.CurrentTail + Inertia + Gravity;
+			FVector SimTailPos = JointState.CurrentTail + Inertia + Gravity + ExternalVel;
 			if (!RestTargetCS.ContainsNaN())
 			{
 				const float StiffScale = Stiffness * DeltaTime;

--- a/Plugins/VRMInterchange/Source/VRMSpringBonesRuntime/Public/AnimNode_VRMSpringBones.h
+++ b/Plugins/VRMInterchange/Source/VRMSpringBonesRuntime/Public/AnimNode_VRMSpringBones.h
@@ -65,6 +65,15 @@ public:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Spring", meta=(PinShownByDefault))
 	TObjectPtr<UVRMSpringBoneData> SpringData = nullptr;
 
+	/** Spring configuration asset (contains joints, springs, colliders) */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Spring", meta = (PinShownByDefault))
+	FVector ExternalVelocity = FVector(0.f, 0.f, 0.f);
+
+	/** Spring configuration asset (contains joints, springs, colliders) */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Spring", meta = (PinShownByDefault))
+	float ExternalVelocityScale = 1.f;
+
+
 	// FAnimNode_Base / SkeletalControl overrides
 	virtual void Initialize_AnyThread(const FAnimationInitializeContext& Context) override;
 	virtual void CacheBones_AnyThread(const FAnimationCacheBonesContext& Context) override;


### PR DESCRIPTION
Add external velocity support to spring simulation

Introduced `ExternalVelocity` and `ExternalVelocityScale` to
allow external forces to influence VRM spring bone simulation.
Updated `SimulateSpringsOnce` to incorporate these properties
by calculating and applying external velocity to the spring
dynamics.

Exposed the new properties in the editor for configuration
(`EditAnywhere`, `BlueprintReadWrite`). These changes enhance
the flexibility and realism of spring bone behavior, making
it more adaptable to dynamic environments.