### PR TITLE
Refactor and enhance VRM import pipelines

### DIFF
--- a/Plugins/VRMInterchange/Content/DefaultPipelines/DefaultSpringBonesPipeline.uasset
+++ b/Plugins/VRMInterchange/Content/DefaultPipelines/DefaultSpringBonesPipeline.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:db1e41d22da733e5ff66ecf1bed11cfa6f7d40fee271c604681ebca57cf2e548
-size 1421
+oid sha256:229aec0e2de41bc2073f058a1b8a99081f68fb21107384e9707871dc2e7ebfed
+size 3481

--- a/Plugins/VRMInterchange/Source/VRMInterchangeEditor/Private/VRMInterchangeEditorModule.cpp
+++ b/Plugins/VRMInterchange/Source/VRMInterchangeEditor/Private/VRMInterchangeEditorModule.cpp
@@ -142,7 +142,7 @@ void FVRMInterchangeEditorModule::StartupModule()
 void FVRMInterchangeEditorModule::ShutdownModule()
 {
 #if WITH_EDITOR
-	HandlePreExit();
+    // HandlePreExit is already bound to FCoreDelegates::OnPreExit; don't call it again here.
 #endif
 }
 

--- a/Plugins/VRMInterchange/Source/VRMInterchangeEditor/Private/VRMSpringBonesPostImportPipeline.h
+++ b/Plugins/VRMInterchange/Source/VRMInterchangeEditor/Private/VRMSpringBonesPostImportPipeline.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "CoreMinimal.h"
-// Use the generic Interchange pipeline base (available across versions)
 #include "InterchangePipelineBase.h"
 #include "VRMSpringBonesPostImportPipeline.generated.h"
 
@@ -10,84 +9,97 @@ class UInterchangeSourceData;
 class UVRMSpringBoneData;
 class USkeleton;
 class USkeletalMesh;
+class UFactory;
 struct FVRMSpringConfig;
-struct FAssetData; // fwd declare for deferred callback
 
+/**
+ * VRM Spring Bones (Post-Import)
+ *
+ * - Parses VRM spring bone data and materializes a SpringBone DataAsset after import confirmation.
+ * - Optionally duplicates a Post-Process AnimBP, injects the SpringConfig, and assigns it to the SkeletalMesh.
+ * - Does NOT save packages during import; marks packages dirty so Save All/SCC handle persistence.
+ */
 UCLASS(BlueprintType, EditInlineNew, DefaultToInstanced, ClassGroup=(Interchange), meta=(DisplayName="VRM Spring Bones (Post-Import)"))
 class VRMINTERCHANGEEDITOR_API UVRMSpringBonesPostImportPipeline : public UInterchangePipelineBase
 {
-    GENERATED_BODY()
+	GENERATED_BODY()
 public:
-    UVRMSpringBonesPostImportPipeline() = default;
+	UVRMSpringBonesPostImportPipeline() = default;
 
 #if WITH_EDITOR
-    // Exposed to the import dialog; default value will be initialized from project settings
-    UPROPERTY(EditAnywhere, Category = "VRM Spring", meta=(DisplayName="Generate Spring Bone Data", ToolTip="Parse VRM spring bone extensions and create a SpringBones DataAsset next to the imported mesh."))
-    bool bGenerateSpringBoneData = true;
+	virtual void PostInitProperties() override;
 
-    UPROPERTY(EditAnywhere, Category = "VRM Spring", meta=(DisplayName="Overwrite Existing", ToolTip="Overwrite existing generated assets. If disabled, a unique name will be chosen."))
-    bool bOverwriteExisting = false;
+	// Dialog toggles (defaults loaded from project settings)
+	UPROPERTY(EditAnywhere, Category = "VRM Spring")
+	bool bGenerateSpringBoneData = true;
 
-    // Phase 3 controls
-    UPROPERTY(EditAnywhere, Category = "VRM Spring", meta=(DisplayName="Generate Post-Process AnimBP", ToolTip="Duplicate a template Post-Process AnimBlueprint next to the imported mesh."))
-    bool bGeneratePostProcessAnimBP = false;
+	UPROPERTY(EditAnywhere, Category = "VRM Spring")
+	bool bOverwriteExisting = false;
 
-    UPROPERTY(EditAnywhere, Category = "VRM Spring", meta=(DisplayName="Assign Post-Process AnimBP", ToolTip="Assign the duplicated Post-Process AnimBP to the imported SkeletalMesh."))
-    bool bAssignPostProcessABP = false;
+	UPROPERTY(EditAnywhere, Category = "VRM Spring")
+	bool bGeneratePostProcessAnimBP = false;
 
-    // New: control whether generated ABP should overwrite existing with same name
-    UPROPERTY(EditAnywhere, Category = "VRM Spring", meta=(DisplayName="Overwrite Post-Process AnimBP", ToolTip="If true, overwrite existing generated Post-Process AnimBlueprints. If false, create a unique name."))
-    bool bOverwriteExistingPostProcessABP = false;
+	UPROPERTY(EditAnywhere, Category = "VRM Spring")
+	bool bAssignPostProcessABP = false;
 
-    // New: control whether to reuse existing ABP on re-import
-    UPROPERTY(EditAnywhere, Category = "VRM Spring", meta=(DisplayName="Reuse Post-Process ABP on Re-Import", ToolTip="If true, attempt to reuse an existing Post-Process AnimBP when re-importing. If false, prompt to overwrite or create new."))
-    bool bReusePostProcessABPOnReimport = true;
+	UPROPERTY(EditAnywhere, Category = "VRM Spring")
+	bool bOverwriteExistingPostProcessABP = false;
 
-    UPROPERTY(EditAnywhere, Category = "VRM Spring", meta=(DisplayName="Animation Sub-Folder"))
-    FString AnimationSubFolder = TEXT("Animation");
+	UPROPERTY(EditAnywhere, Category = "VRM Spring")
+	bool bReusePostProcessABPOnReimport = true;
 
-    UPROPERTY(EditAnywhere, Category = "VRM Spring", meta=(DisplayName="Sub-Folder"))
-    FString SubFolder = TEXT("SpringBones");
+	UPROPERTY(EditAnywhere, Category = "VRM Spring")
+	FString AnimationSubFolder = TEXT("Animation");
 
-    UPROPERTY(EditAnywhere, Category = "VRM Spring", meta=(DisplayName="Data Asset Name"))
-    FString DataAssetName = TEXT("SpringBonesData");
+	UPROPERTY(EditAnywhere, Category = "VRM Spring")
+	FString SubFolder = TEXT("SpringBones");
 
-    // Initialize per-instance defaults from project settings so the import dialog reflects user preferences
-    virtual void PostInitProperties() override;
+	UPROPERTY(EditAnywhere, Category = "VRM Spring")
+	FString DataAssetName = TEXT("SpringBonesData");
 #endif
 
-    // UInterchangePipelineBase
-    virtual void ExecutePipeline(UInterchangeBaseNodeContainer* BaseNodeContainer, const TArray<UInterchangeSourceData*>& SourceDatas, const FString& ContentBasePath) override;
+	// UInterchangePipelineBase
+	virtual void ExecutePipeline(UInterchangeBaseNodeContainer* BaseNodeContainer, const TArray<UInterchangeSourceData*>& SourceDatas, const FString& ContentBasePath) override;
+
+#if WITH_EDITOR
+	virtual void BeginDestroy() override;
+#endif
 
 private:
 #if WITH_EDITOR
-    bool ParseAndFillDataAssetFromFile(const FString& Filename, UVRMSpringBoneData* Dest) const;
-    FString MakeTargetPathAndName(const FString& SourceFilename, const FString& ContentBasePath, FString& OutPackagePath, FString& OutAssetName) const;
-    bool ResolveBoneNamesFromFile(const FString& Filename, FVRMSpringConfig& InOut, int32& OutResolvedColliders, int32& OutResolvedJoints, int32& OutResolvedCenters) const;
-    void ValidateBoneNamesAgainstSkeleton(const FString& SearchRootPackagePath, const FVRMSpringConfig& Config) const;
+	// Parsing/materialization helpers
+	bool ParseAndFillDataAssetFromFile(const FString& Filename, UVRMSpringBoneData* Dest) const;
+	FString MakeTargetPathAndName(const FString& SourceFilename, const FString& ContentBasePath, FString& OutPackagePath, FString& OutAssetName) const;
+	bool ResolveBoneNamesFromFile(const FString& Filename, FVRMSpringConfig& InOut, int32& OutResolvedColliders, int32& OutResolvedJoints, int32& OutResolvedCenters) const;
+	void ValidateBoneNamesAgainstSkeleton(const FString& SearchRootPackagePath, const FVRMSpringConfig& Config) const;
 
-    // Phase 3 helpers
-    bool FindImportedSkeletalAssets(const FString& SearchRootPackagePath, USkeletalMesh*& OutSkeletalMesh, USkeleton*& OutSkeleton) const;
-    UObject* DuplicateTemplateAnimBlueprint(const FString& TargetPackagePath, const FString& BaseName, USkeleton* TargetSkeleton, bool bOverwriteExistingABP) const;
-    bool SetSpringConfigOnAnimBlueprint(UObject* AnimBlueprintObj, UVRMSpringBoneData* SpringData) const;
-    bool AssignPostProcessABPToMesh(USkeletalMesh* SkelMesh, UObject* AnimBlueprintObj) const;
+	// Asset helpers
+	bool FindImportedSkeletalAssets(const FString& SearchRootPackagePath, USkeletalMesh*& OutSkeletalMesh, USkeleton*& OutSkeleton) const;
+	UObject* DuplicateTemplateAnimBlueprint(const FString& TargetPackagePath, const FString& BaseName, USkeleton* TargetSkeleton, bool bOverwriteExistingABP) const;
+	bool SetSpringConfigOnAnimBlueprint(UObject* AnimBlueprintObj, UVRMSpringBoneData* SpringData) const;
+	bool AssignPostProcessABPToMesh(USkeletalMesh* SkelMesh, UObject* AnimBlueprintObj) const;
+	FString GetParentPackagePath(const FString& InPath) const;
 
-    // Package path helper
-    FString GetParentPackagePath(const FString& InPath) const;
+	// Post-import deferral
+	void RegisterPostImportCommit();
+	void UnregisterPostImportCommit();
+	void OnAssetPostImport(class UFactory* InFactory, UObject* InCreatedObject);
 
-    // Deferred ABP scaffolding when skeletal assets are not yet available
-    void RegisterDeferredABP(const FString& InSkeletonSearchRoot, const FString& InPackagePath, UVRMSpringBoneData* InSpringData, bool bInWantsAssign);
-    void UnregisterDeferredABP();
-    void OnAssetAddedForDeferredABP(const struct FAssetData& AssetData);
-
-    // Deferred state
-    FDelegateHandle DeferredHandle;
-    FString DeferredSkeletonSearchRoot;
-    FString DeferredAltSkeletonSearchRoot; // parent of root
-    FString DeferredPackagePath;
-    TWeakObjectPtr<UVRMSpringBoneData> DeferredSpringDataAsset;
-    bool bDeferredWantsAssign = false;
-    bool bDeferredCompleted = false;
+	// Deferred state for post-import commit
+	FDelegateHandle ImportPostHandle;
+	FString DeferredSkeletonSearchRoot;
+	FString DeferredAltSkeletonSearchRoot; // parent of root
+	FString DeferredPackagePath;
+	TStrongObjectPtr<UVRMSpringBoneData> DeferredSpringDataTransient;
+	bool bDeferredWantsAssign = false;
+	bool bDeferredCompleted = false;
+	FString DeferredAnimFolder;
+	FString DeferredDesiredABPName;
+	bool bDeferredOverwriteABP = false;
+	bool bDeferredOverwriteSpringAsset = false;
+	bool bDeferredReuseABP = true;
+	FString DeferredSourceFilename;
+	FString DeferredSourceHash;
 #endif
 };
 

--- a/Plugins/VRMInterchange/Source/VRMInterchangeEditor/Public/VRMInterchangeSettings.h
+++ b/Plugins/VRMInterchange/Source/VRMInterchangeEditor/Public/VRMInterchangeSettings.h
@@ -4,6 +4,7 @@
 #include "Engine/DeveloperSettings.h"
 #include "VRMInterchangeSettings.generated.h"
 
+
 UCLASS(config=Game, defaultconfig, meta=(DisplayName="VRM Interchange"))
 class VRMINTERCHANGEEDITOR_API UVRMInterchangeSettings : public UDeveloperSettings
 {

--- a/Plugins/VRMInterchange/Source/VRMSpringBonesRuntime/Private/AnimNode_VRMSpringBones.cpp
+++ b/Plugins/VRMInterchange/Source/VRMSpringBonesRuntime/Private/AnimNode_VRMSpringBones.cpp
@@ -288,7 +288,8 @@ void FAnimNode_VRMSpringBones::SimulateSpringsOnce(const FComponentSpacePoseCont
 		const bool  bHasColliders  = Spring.ColliderGroupIndices.Num() > 0;
 		const FVector GravityDir   = Spring.GravityDir;
 		const float DefaultHitRadius = FMath::Max(0.f, Spring.HitRadius * 100.0f);
-		const FVector ExternalVel	= ExternalVelocity * ExternalVelocityScale * DeltaTime;
+		const FVector ExternalVel	= (ComponentTM.InverseTransformVector(ExternalVelocity) * ExternalVelocityScale) * DeltaTime * (1.f - Drag);
+		const FVector Gravity = GravityDir * GravityPower * DeltaTime;
 
 		for (int32 ChainPos = 0; ChainPos < SpringChainRng.Num; ++ChainPos)
 		{
@@ -317,8 +318,6 @@ void FAnimNode_VRMSpringBones::SimulateSpringsOnce(const FComponentSpacePoseCont
 			const FVector CurrentHeadPosCS = bIsSpringRoot ? JointBoneCS.GetTranslation() : ParentState.PrevTail;
 
 			FVector Inertia = (JointState.CurrentTail - JointState.PrevTail) * (1.f - Drag);
-			FVector Gravity = GravityDir * GravityPower * DeltaTime;
-
 			const FQuat AnimatedBoneRotCS = JointBoneCS.GetRotation();
 			const FVector RestTargetCS = CurrentHeadPosCS + AnimatedBoneRotCS.RotateVector(JointState.InitialLocalChildPos);
 


### PR DESCRIPTION
Refactor and enhance VRM import pipelines

Refactored VRM import pipelines to improve modularity, asset creation, and post-import handling. Key changes include:

- Replaced legacy deferred asset creation with `UImportSubsystem`'s `OnAssetPostImport` callback.
- Updated `ExecutePipeline` methods to stage asset creation and defer materialization until post-import.
- Improved asset duplication logic with better handling of overwrites and unique naming.
- Enhanced SpringBone data parsing and validation against skeletons.
- Added support for reusing existing AnimBlueprints during re-import.
- Deferred IK Rig creation until skeletal assets are available.
- Introduced new project settings for asset generation, overwrites, and reuse.
- Fixed external velocity calculations in `FAnimNode_VRMSpringBones`.
- Removed legacy code for deferred asset creation using `FAssetRegistryModule`.

These changes improve code clarity, performance, and user experience during VRM asset import workflows.