### PR TITLE
Include VRMSpringBoneData header and remove forward decl

### DIFF
--- a/Plugins/VRMInterchange/Source/VRMInterchangeEditor/Private/VRMSpringBonesPostImportPipeline.h
+++ b/Plugins/VRMInterchange/Source/VRMInterchangeEditor/Private/VRMSpringBonesPostImportPipeline.h
@@ -2,11 +2,11 @@
 
 #include "CoreMinimal.h"
 #include "InterchangePipelineBase.h"
+#include "VRMSpringBoneData.h" // Ensure UVRMSpringBoneData is a complete type here
 #include "VRMSpringBonesPostImportPipeline.generated.h"
 
 class UInterchangeBaseNodeContainer;
 class UInterchangeSourceData;
-class UVRMSpringBoneData;
 class USkeleton;
 class USkeletalMesh;
 class UFactory;


### PR DESCRIPTION
Include VRMSpringBoneData header and remove forward decl

Added `#include "VRMSpringBoneData.h"` to ensure `UVRMSpringBoneData` is a complete type in the header file. Removed the forward declaration of `UVRMSpringBoneData` as it is now redundant due to the inclusion of the header file.