### PR TITLE
Fix VRM1 spring-joint index bug; reject malformed spring configs before import

### DIFF
--- a/Plugins/VRMInterchange/Source/VRMInterchange/Private/VRMSpringBonesParser.cpp
+++ b/Plugins/VRMInterchange/Source/VRMInterchange/Private/VRMSpringBonesParser.cpp
@@ -530,7 +530,14 @@ namespace
                         }
                         else
                         {
-                            S.JointIndices.Add((int32)JV->AsNumber());
+                            // Plain-number joint entry (non-standard for VRM1, but tolerate it):
+                            // the number is a glTF node index, not an Out.Joints array index, so
+                            // wrap it in a joint entry and use the index Add() returns - same
+                            // pattern as the object-form branch above and ParseVRM0 below.
+                            FVRMSpringJoint J;
+                            J.NodeIndex = JV.IsValid() ? (int32)JV->AsNumber() : INDEX_NONE;
+                            const int32 NewJointIndex = Out.Joints.Add(MoveTemp(J));
+                            S.JointIndices.Add(NewJointIndex);
                         }
                     }
                 }

--- a/Plugins/VRMInterchange/Source/VRMInterchange/Private/VRMSpringBonesParser.cpp
+++ b/Plugins/VRMInterchange/Source/VRMInterchange/Private/VRMSpringBonesParser.cpp
@@ -534,8 +534,12 @@ namespace
                             // the number is a glTF node index, not an Out.Joints array index, so
                             // wrap it in a joint entry and use the index Add() returns - same
                             // pattern as the object-form branch above and ParseVRM0 below.
+                            // Use TryGetNumber rather than AsNumber: a malformed file could put a
+                            // non-numeric value here, and AsNumber() logs/asserts on type mismatch
+                            // instead of failing quietly.
                             FVRMSpringJoint J;
-                            J.NodeIndex = JV.IsValid() ? (int32)JV->AsNumber() : INDEX_NONE;
+                            double NodeIndexNum = 0.0;
+                            J.NodeIndex = (JV.IsValid() && JV->TryGetNumber(NodeIndexNum)) ? (int32)NodeIndexNum : INDEX_NONE;
                             const int32 NewJointIndex = Out.Joints.Add(MoveTemp(J));
                             S.JointIndices.Add(NewJointIndex);
                         }

--- a/Plugins/VRMInterchange/Source/VRMInterchangeEditor/Private/VRMSpringBonesPostImportPipeline.cpp
+++ b/Plugins/VRMInterchange/Source/VRMInterchangeEditor/Private/VRMSpringBonesPostImportPipeline.cpp
@@ -19,6 +19,7 @@
 #include "UObject/Package.h"
 #include "Misc/SecureHash.h"
 #include "VRMSpringBonesParser.h"
+#include "VRMSpringBonesValidation.h"
 #include "VRMInterchangeLog.h"
 #include "VRMInterchangeSettings.h"
 
@@ -200,6 +201,26 @@ bool UVRMSpringBonesPostImportPipeline::ParseAndFillDataAssetFromFile(const FStr
     if (!bParsed)
     {
         return false;
+    }
+
+    // Reject malformed configs (e.g. joint/collider/group indices out of range) before they ever
+    // reach BuildResolvedChildren() or the runtime spring solver, both of which index into these
+    // arrays without their own bounds checks.
+    {
+        const VRM::FVRMValidationResult Validation = VRM::ValidateSpringConfig(Config);
+        for (const FString& Warning : Validation.Warnings)
+        {
+            UE_LOG(LogVRMSpring, Warning, TEXT("[VRMInterchange] Spring pipeline: %s (%s)"), *Warning, *Filename);
+        }
+        if (!Validation.bIsValid)
+        {
+            for (const FString& Error : Validation.Errors)
+            {
+                UE_LOG(LogVRMSpring, Error, TEXT("[VRMInterchange] Spring pipeline: %s (%s)"), *Error, *Filename);
+            }
+            UE_LOG(LogVRMSpring, Error, TEXT("[VRMInterchange] Spring pipeline: Rejecting spring bone data from '%s' due to validation errors above; skipping spring asset generation."), *Filename);
+            return false;
+        }
     }
 
     Dest->SpringConfig = MoveTemp(Config);

--- a/Plugins/VRMInterchange/Source/VRMInterchangeEditor/Private/VRMSpringBonesPostImportPipeline.cpp
+++ b/Plugins/VRMInterchange/Source/VRMInterchangeEditor/Private/VRMSpringBonesPostImportPipeline.cpp
@@ -208,15 +208,15 @@ bool UVRMSpringBonesPostImportPipeline::ParseAndFillDataAssetFromFile(const FStr
     // arrays without their own bounds checks.
     {
         const VRM::FVRMValidationResult Validation = VRM::ValidateSpringConfig(Config);
-        for (const FString& Warning : Validation.Warnings)
+        for (const FString& WarningMsg : Validation.Warnings)
         {
-            UE_LOG(LogVRMSpring, Warning, TEXT("[VRMInterchange] Spring pipeline: %s (%s)"), *Warning, *Filename);
+            UE_LOG(LogVRMSpring, Warning, TEXT("[VRMInterchange] Spring pipeline: %s (%s)"), *WarningMsg, *Filename);
         }
         if (!Validation.bIsValid)
         {
-            for (const FString& Error : Validation.Errors)
+            for (const FString& ErrorMsg : Validation.Errors)
             {
-                UE_LOG(LogVRMSpring, Error, TEXT("[VRMInterchange] Spring pipeline: %s (%s)"), *Error, *Filename);
+                UE_LOG(LogVRMSpring, Error, TEXT("[VRMInterchange] Spring pipeline: %s (%s)"), *ErrorMsg, *Filename);
             }
             UE_LOG(LogVRMSpring, Error, TEXT("[VRMInterchange] Spring pipeline: Rejecting spring bone data from '%s' due to validation errors above; skipping spring asset generation."), *Filename);
             return false;


### PR DESCRIPTION
## Summary
- A code audit of the VRMInterchange plugin (separate from the VMCLiveLink audit in #92) found a parser bug that can crash the Editor on import of certain VRM 1.0 files, plus a validation function that would have caught it but was never wired into the pipeline. This PR fixes both.
- `VRMSpringBonesParser.cpp` (`ParseVRM1`): the `springs[].joints[]` plain-number branch pushed the raw glTF node index directly into `FVRMSpring::JointIndices`, instead of adding a joint entry to `Out.Joints` and using the array index `Add()` returns — the pattern already used by the adjacent object-form branch and by `ParseVRM0`. That produced `JointIndices` values with no relationship to `Out.Joints.Num()`.
- `UVRMSpringBoneData::BuildResolvedChildren()` indexes `Cfg.Joints[JointIdx]` with no bounds check and is called unconditionally right after parsing — so a VRM1 file using this joint format triggers an out-of-bounds `TArray` read in the Editor on import.
- `VRM::ValidateSpringConfig()` already implements the exact range checks that would catch this (and other malformed-index cases), but had zero callers anywhere in the plugin — it looked like a safety net but provided none.
- Fix: correct the parser to always route joint references through `Out.Joints`, and wire `ValidateSpringConfig()` into `ParseAndFillDataAssetFromFile()` so any validation error causes the spring data to be rejected (skipping spring asset generation for that import, logging why) instead of reaching `BuildResolvedChildren()` or the runtime spring solver — neither of which independently bounds-checks this data.

## Test plan
- [ ] Import a VRM 1.0 file whose `VRMC_springBone.springs[].joints[]` entries are plain numbers rather than `{node, hitRadius}` objects; confirm the Editor no longer crashes and spring data imports correctly.
- [ ] Import a VRM file with an intentionally out-of-range spring/collider index; confirm the spring asset is skipped with a clear error in the log rather than crashing.
- [ ] Import a normal, well-formed VRM file with spring bones and confirm behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01MW7wvCCJMYkutmehmWzqHU)_