### PR TITLE
Fix root-transform crash, subject-bootstrap race, dead code, CI verify

### DIFF
--- a/.github/workflows/fab-plugin-build.yml
+++ b/.github/workflows/fab-plugin-build.yml
@@ -43,14 +43,14 @@ jobs:
           if (-not (Test-Path "scripts\build_fab.ps1")) {
             Write-Error "scripts/build_fab.ps1 not found. Commit the script to scripts/build_fab.ps1 or update the workflow path."
           }
-          if (-not (Test-Path "scripts\add_copyright_headers.py")) {
-            Write-Error "scripts/add_copyright_headers.py not found. Commit the script to scripts/add_copyright_headers.py or update the workflow path."
+          if (-not (Test-Path "scripts\verify_copyright_headers.ps1")) {
+            Write-Error "scripts/verify_copyright_headers.ps1 not found. Commit the script to scripts/verify_copyright_headers.ps1 or update the workflow path."
           }
 
       - name: Verify copyright headers
         run: |
           $PluginDir = $env:PLUGIN_DIR
-          python "scripts\add_copyright_headers.py" $PluginDir --holder "Lifelike & Believable Animation Design, Inc." --verify
+          ./scripts/verify_copyright_headers.ps1 -PluginDir $PluginDir -Holder "Lifelike & Believable Animation Design, Inc. | Athomas Goldberg"
 
       - name: Build Fab packages (VMCLiveLink and VRMInterchange)
         run: |
@@ -203,6 +203,7 @@ jobs:
 
       - name: Create GitHub Release
         id: create_release
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/release/')
         uses: actions/create-release@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -213,6 +214,7 @@ jobs:
           prerelease: false
 
       - name: Upload release asset (Combined VRM & VMC files .zip)
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/release/')
         uses: actions/upload-release-asset@v1
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
@@ -221,6 +223,7 @@ jobs:
           asset_content_type: application/zip
 
       - name: Upload release asset (VMCLiveLink-only.zip)
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/release/')
         uses: actions/upload-release-asset@v1
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
@@ -229,6 +232,7 @@ jobs:
           asset_content_type: application/zip
 
       - name: Upload release asset (VRMInterchange-only.zip)
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/release/')
         uses: actions/upload-release-asset@v1
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}

--- a/.github/workflows/header-autofix.yml
+++ b/.github/workflows/header-autofix.yml
@@ -10,7 +10,7 @@ on:
       holder:
         description: "Copyright holder text"
         required: true
-        default: "Lifelike & Believable Animation Design, Inc."
+        default: "Lifelike & Believable Animation Design, Inc. | Athomas Goldberg"
 
 permissions:
   contents: write

--- a/Plugins/VMCLiveLink/Source/VMCLiveLink/Private/VMCLiveLinkMappingAsset.cpp
+++ b/Plugins/VMCLiveLink/Source/VMCLiveLink/Private/VMCLiveLinkMappingAsset.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 ...
+// Copyright (c) 2025-2026 Lifelike & Believable Animation Design, Inc. | Athomas Goldberg. All Rights Reserved.
 #include "VMCLiveLinkMappingAsset.h"
 
 #if WITH_EDITOR

--- a/Plugins/VMCLiveLink/Source/VMCLiveLink/Private/VMCLiveLinkModule.cpp
+++ b/Plugins/VMCLiveLink/Source/VMCLiveLink/Private/VMCLiveLinkModule.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Lifelike & Believable Animation Design, Inc. | Athomas Goldberg. All Rights Reserved.
+// Copyright (c) 2025-2026 Lifelike & Believable Animation Design, Inc. | Athomas Goldberg. All Rights Reserved.
 #include "Modules/ModuleManager.h"
 #include "VMCLog.h"
 

--- a/Plugins/VMCLiveLink/Source/VMCLiveLink/Private/VMCLiveLinkRemapper.cpp
+++ b/Plugins/VMCLiveLink/Source/VMCLiveLink/Private/VMCLiveLinkRemapper.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Lifelike & Believable Animation Design, Inc. | Athomas Goldberg. All Rights Reserved.
+// Copyright (c) 2025-2026 Lifelike & Believable Animation Design, Inc. | Athomas Goldberg. All Rights Reserved.
 #include "VMCLiveLinkRemapper.h"
 
 #include "Dom/JsonObject.h"

--- a/Plugins/VMCLiveLink/Source/VMCLiveLink/Private/VMCLiveLinkSettings.cpp
+++ b/Plugins/VMCLiveLink/Source/VMCLiveLink/Private/VMCLiveLinkSettings.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Lifelike & Believable Animation Design, Inc. | Athomas Goldberg. All Rights Reserved.
+// Copyright (c) 2025-2026 Lifelike & Believable Animation Design, Inc. | Athomas Goldberg. All Rights Reserved.
 #include "VMCLiveLinkSettings.h"
 #include "VMCLiveLinkRemapper.h"
 #include "Engine/SkeletalMesh.h"

--- a/Plugins/VMCLiveLink/Source/VMCLiveLink/Private/VMCLiveLinkSource.cpp
+++ b/Plugins/VMCLiveLink/Source/VMCLiveLink/Private/VMCLiveLinkSource.cpp
@@ -256,9 +256,12 @@ void FVMCLiveLinkSource::OnOscMessageReceived(const FOSCMessage& Msg, const FStr
         // settings, not our default remapper) before this ever ran on the first Apply.
         if (!bEnsuredDefaults)
         {
-            EnsureSubjectSettingsWithDefaults();
+            EnsureSubjectSettingsWithDefaults(); // already calls RefreshStaticMapsFromSettings() internally
         }
-        RefreshStaticMapsFromSettings();
+        else
+        {
+            RefreshStaticMapsFromSettings();
+        }
 
         if (bForceStaticNext || !bStaticSent)
         {

--- a/Plugins/VMCLiveLink/Source/VMCLiveLink/Private/VMCLiveLinkSource.cpp
+++ b/Plugins/VMCLiveLink/Source/VMCLiveLink/Private/VMCLiveLinkSource.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Lifelike & Believable Animation Design, Inc. | Athomas Goldberg. All Rights Reserved.
+// Copyright (c) 2025-2026 Lifelike & Believable Animation Design, Inc. | Athomas Goldberg. All Rights Reserved.
 #include "VMCLiveLinkSource.h"
 #include "VMCLog.h"
 
@@ -249,13 +249,15 @@ void FVMCLiveLinkSource::OnOscMessageReceived(const FOSCMessage& Msg, const FStr
     }
     else if (Addr == TEXT("/VMC/Ext/Blend/Apply"))
     {
-        AsyncTask(ENamedThreads::GameThread, [this]()
+        // If we haven't yet attached defaults, do it now. OSC messages are always
+        // dispatched on the Game Thread (see UOSCServer::PumpPacketQueue), so this can
+        // run synchronously; deferring it via AsyncTask raced the PushStaticData/PushFrame
+        // calls below and could let the subject get auto-created (with generic default
+        // settings, not our default remapper) before this ever ran on the first Apply.
+        if (!bEnsuredDefaults)
         {
-            if (!bEnsuredDefaults)
-            {
-                EnsureSubjectSettingsWithDefaults();
-            }
-        });
+            EnsureSubjectSettingsWithDefaults();
+        }
         RefreshStaticMapsFromSettings();
 
         if (bForceStaticNext || !bStaticSent)
@@ -457,23 +459,6 @@ uint32 FVMCLiveLinkSource::HashMaps(const TMap<FName, FName>& A, const TMap<FNam
         };
     Mix(A); Mix(B);
     return H;
-}
-
-void FVMCLiveLinkSource::RefreshStaticMapsIfNeeded()
-{
-    UVMCLiveLinkRemapper* R = StaticNameRemapper.LoadSynchronous();
-    if (!R) return;
-
-    const uint32 NewHash = HashMaps(R->BoneNameMap, R->CurveNameMap);
-    if (NewHash != CachedMapsHash)
-    {
-        CachedMapsHash = NewHash;
-        CachedBoneMap = R->BoneNameMap;
-        CachedCurveMap = R->CurveNameMap;
-
-        // Force one static publish on next /Apply to propagate new names
-        bForceStaticNext = true;
-    }
 }
 
 void FVMCLiveLinkSource::BuildRefOffsetsFromMesh(USkeletalMesh* Mesh)

--- a/Plugins/VMCLiveLink/Source/VMCLiveLink/Private/VMCLiveLinkSource.cpp
+++ b/Plugins/VMCLiveLink/Source/VMCLiveLink/Private/VMCLiveLinkSource.cpp
@@ -385,9 +385,19 @@ void FVMCLiveLinkSource::PushFrame()
         // Translation handling
         if (LocalBoneParents.IsValidIndex(i) && LocalBoneParents[i] == -1)
         {
-            // Root gets live root translation
-            const FTransform* In = LocalPose.Find(SrcName);
-            X.SetTranslation(In->GetTranslation());
+            // Root gets live root translation. Prefer a Bone/Pos entry explicitly
+            // named "root" if the sender provided one; otherwise fall back to the
+            // dedicated /VMC/Ext/Root/Pos stream (LocalRoot), which is the common case
+            // and the only source of root data with the bundled sample sender.
+            if (const FTransform* In = LocalPose.Find(SrcName))
+            {
+                X.SetTranslation(In->GetTranslation());
+            }
+            else
+            {
+                X.SetTranslation(LocalRoot.GetTranslation());
+                X.SetRotation(LocalRoot.GetRotation());
+            }
         }
         else
         {

--- a/Plugins/VMCLiveLink/Source/VMCLiveLink/Private/VMCLiveLinkSourceFactory.cpp
+++ b/Plugins/VMCLiveLink/Source/VMCLiveLink/Private/VMCLiveLinkSourceFactory.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Lifelike & Believable Animation Design, Inc. | Athomas Goldberg. All Rights Reserved.
+// Copyright (c) 2025-2026 Lifelike & Believable Animation Design, Inc. | Athomas Goldberg. All Rights Reserved.
 
 #include "VMCLiveLinkSourceFactory.h"
 #include "VMCLiveLinkSource.h"

--- a/Plugins/VMCLiveLink/Source/VMCLiveLink/Private/VMCLog.cpp
+++ b/Plugins/VMCLiveLink/Source/VMCLiveLink/Private/VMCLog.cpp
@@ -1,3 +1,3 @@
-// Copyright (c) 2025 Lifelike & Believable Animation Design, Inc. | Athomas Goldberg. All Rights Reserved.
+// Copyright (c) 2025-2026 Lifelike & Believable Animation Design, Inc. | Athomas Goldberg. All Rights Reserved.
 #include "VMCLog.h"
 DEFINE_LOG_CATEGORY(LogVMCLiveLink);

--- a/Plugins/VMCLiveLink/Source/VMCLiveLink/Private/VMCLog.h
+++ b/Plugins/VMCLiveLink/Source/VMCLiveLink/Private/VMCLog.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Lifelike & Believable Animation Design, Inc. | Athomas Goldberg. All Rights Reserved.
+// Copyright (c) 2025-2026 Lifelike & Believable Animation Design, Inc. | Athomas Goldberg. All Rights Reserved.
 #pragma once
 #include "CoreMinimal.h"
 

--- a/Plugins/VMCLiveLink/Source/VMCLiveLink/Public/VMCLiveLinkMappingAsset.h
+++ b/Plugins/VMCLiveLink/Source/VMCLiveLink/Public/VMCLiveLinkMappingAsset.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 ...
+// Copyright (c) 2025-2026 Lifelike & Believable Animation Design, Inc. | Athomas Goldberg. All Rights Reserved.
 #pragma once
 
 #include "CoreMinimal.h"

--- a/Plugins/VMCLiveLink/Source/VMCLiveLink/Public/VMCLiveLinkRemapper.h
+++ b/Plugins/VMCLiveLink/Source/VMCLiveLink/Public/VMCLiveLinkRemapper.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Lifelike & Believable Animation Design, Inc. | Athomas Goldberg. All Rights Reserved.
+// Copyright (c) 2025-2026 Lifelike & Believable Animation Design, Inc. | Athomas Goldberg. All Rights Reserved.
 #pragma once
 
 #include "CoreMinimal.h"

--- a/Plugins/VMCLiveLink/Source/VMCLiveLink/Public/VMCLiveLinkSettings.h
+++ b/Plugins/VMCLiveLink/Source/VMCLiveLink/Public/VMCLiveLinkSettings.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Lifelike & Believable Animation Design, Inc. | Athomas Goldberg. All Rights Reserved.
+// Copyright (c) 2025-2026 Lifelike & Believable Animation Design, Inc. | Athomas Goldberg. All Rights Reserved.
 #pragma once
 #include "Engine/DeveloperSettings.h"
 #include "VMCLiveLinkSettings.generated.h"

--- a/Plugins/VMCLiveLink/Source/VMCLiveLink/Public/VMCLiveLinkSource.h
+++ b/Plugins/VMCLiveLink/Source/VMCLiveLink/Public/VMCLiveLinkSource.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Lifelike & Believable Animation Design, Inc. | Athomas Goldberg. All Rights Reserved.
+// Copyright (c) 2025-2026 Lifelike & Believable Animation Design, Inc. | Athomas Goldberg. All Rights Reserved.
 #pragma once
 
 #include "CoreMinimal.h"
@@ -13,7 +13,6 @@ struct FOSCMessage;
 
 class ULiveLinkSubjectRemapper;
 class ULiveLinkSubjectSettings;
-class UVMCLiveLinkRemapper;
 
 /**
  * VMC → Live Link source (UE 5.6)
@@ -37,9 +36,6 @@ public:
     virtual FText GetSourceType() const override { return NSLOCTEXT("VMCLiveLink", "SourceType", "VMC (OSC)"); }
     virtual FText GetSourceMachineName() const override { return FText::FromString(TEXT("Local/Network")); }
     virtual FText GetSourceStatus() const override;
-    // Optional: point this to the same remapper asset you use in Subject Settings (or a duplicate)
-    UPROPERTY(EditAnywhere, Category = "Remap")
-    TSoftObjectPtr<UVMCLiveLinkRemapper> StaticNameRemapper;
 
 private:
     // OSC lifecycle
@@ -68,7 +64,6 @@ private:
     bool bForceStaticNext = false;
 
     // Helpers
-    void RefreshStaticMapsIfNeeded();
     void RefreshStaticMapsFromSettings(); // (we’ll extend this to also pull the ReferenceSkeleton)
     static uint32 HashMaps(const TMap<FName, FName>& A, const TMap<FName, FName>& B);
     void BuildRefOffsetsFromMesh(class USkeletalMesh* Mesh);
@@ -98,7 +93,6 @@ private:
 
     // Static (skeleton) tracking
     bool bStaticSent = false;
-    int32 LastRemapVersion = -1;
 
     // Bones
     TArray<FName> BoneNames;    // index-aligned

--- a/Plugins/VMCLiveLink/Source/VMCLiveLink/Public/VMCLiveLinkSourceFactory.h
+++ b/Plugins/VMCLiveLink/Source/VMCLiveLink/Public/VMCLiveLinkSourceFactory.h
@@ -18,7 +18,7 @@ public:
 	virtual FText GetSourceTooltip() const override { return NSLOCTEXT("VMCLiveLink", "Tooltip", "Receive VMC (OSC) motion/curves"); }
 
 #if WITH_EDITOR
-	// Editor-only UI surface  kept out of runtime builds
+	// Editor-only UI surface - kept out of runtime builds
 	virtual EMenuType GetMenuType() const override { return EMenuType::SubPanel; }
 	virtual TSharedPtr<SWidget> BuildCreationPanel(FOnLiveLinkSourceCreated OnLiveLinkSourceCreated) const override;
 #endif

--- a/Plugins/VMCLiveLink/Source/VMCLiveLink/Public/VMCLiveLinkSourceFactory.h
+++ b/Plugins/VMCLiveLink/Source/VMCLiveLink/Public/VMCLiveLinkSourceFactory.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Lifelike & Believable Animation Design, Inc. | Athomas Goldberg. All Rights Reserved.
+// Copyright (c) 2025-2026 Lifelike & Believable Animation Design, Inc. | Athomas Goldberg. All Rights Reserved.
 #pragma once
 
 #include "LiveLinkSourceFactory.h"
@@ -18,7 +18,7 @@ public:
 	virtual FText GetSourceTooltip() const override { return NSLOCTEXT("VMCLiveLink", "Tooltip", "Receive VMC (OSC) motion/curves"); }
 
 #if WITH_EDITOR
-	// Editor-only UI surface — kept out of runtime builds
+	// Editor-only UI surface  kept out of runtime builds
 	virtual EMenuType GetMenuType() const override { return EMenuType::SubPanel; }
 	virtual TSharedPtr<SWidget> BuildCreationPanel(FOnLiveLinkSourceCreated OnLiveLinkSourceCreated) const override;
 #endif

--- a/Plugins/VMCLiveLink/Source/VMCLiveLinkEditor/Private/AssetTypeActions_VMCLiveLinkMappingAsset.cpp
+++ b/Plugins/VMCLiveLink/Source/VMCLiveLinkEditor/Private/AssetTypeActions_VMCLiveLinkMappingAsset.cpp
@@ -1,3 +1,4 @@
+// Copyright (c) 2026 Lifelike & Believable Animation Design, Inc. | Athomas Goldberg. All Rights Reserved.
 #include "AssetTypeActions_VMCLiveLinkMappingAsset.h"
 #include "VMCLiveLinkMappingAsset.h"
 #include "VMCLiveLinkEditorModule.h"

--- a/Plugins/VMCLiveLink/Source/VMCLiveLinkEditor/Private/AssetTypeActions_VMCLiveLinkMappingAsset.h
+++ b/Plugins/VMCLiveLink/Source/VMCLiveLinkEditor/Private/AssetTypeActions_VMCLiveLinkMappingAsset.h
@@ -1,3 +1,4 @@
+// Copyright (c) 2026 Lifelike & Believable Animation Design, Inc. | Athomas Goldberg. All Rights Reserved.
 #pragma once
 
 #include "AssetTypeActions_Base.h"

--- a/Plugins/VMCLiveLink/Source/VMCLiveLinkEditor/Private/VMCLiveLinkEditorModule.cpp
+++ b/Plugins/VMCLiveLink/Source/VMCLiveLinkEditor/Private/VMCLiveLinkEditorModule.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Lifelike & Believable Animation Design, Inc. | Athomas Goldberg. All Rights Reserved.
+// Copyright (c) 2025-2026 Lifelike & Believable Animation Design, Inc. | Athomas Goldberg. All Rights Reserved.
 #include "VMCLiveLinkEditorModule.h"
 #include "Modules/ModuleManager.h"
 #include "IAssetTools.h"

--- a/Plugins/VMCLiveLink/Source/VMCLiveLinkEditor/Private/VMCLiveLinkEditorModule.h
+++ b/Plugins/VMCLiveLink/Source/VMCLiveLinkEditor/Private/VMCLiveLinkEditorModule.h
@@ -1,3 +1,4 @@
+// Copyright (c) 2026 Lifelike & Believable Animation Design, Inc. | Athomas Goldberg. All Rights Reserved.
 #pragma once
 #include "CoreMinimal.h"
 #include "IAssetTools.h"

--- a/Plugins/VMCLiveLink/Source/VMCLiveLinkEditor/Private/VMCLiveLinkMappingAssetFactory.cpp
+++ b/Plugins/VMCLiveLink/Source/VMCLiveLinkEditor/Private/VMCLiveLinkMappingAssetFactory.cpp
@@ -1,3 +1,4 @@
+// Copyright (c) 2026 Lifelike & Believable Animation Design, Inc. | Athomas Goldberg. All Rights Reserved.
 #include "VMCLiveLinkMappingAssetFactory.h"
 #include "VMCLiveLinkMappingAsset.h"
 #include "VMCLiveLinkEditorModule.h"

--- a/Plugins/VMCLiveLink/Source/VMCLiveLinkEditor/Private/VMCLiveLinkMappingAssetFactory.h
+++ b/Plugins/VMCLiveLink/Source/VMCLiveLinkEditor/Private/VMCLiveLinkMappingAssetFactory.h
@@ -1,3 +1,4 @@
+// Copyright (c) 2026 Lifelike & Believable Animation Design, Inc. | Athomas Goldberg. All Rights Reserved.
 #pragma once
 #include "CoreMinimal.h"
 #include "Factories/Factory.h"

--- a/Plugins/VMCLiveLink/Source/VMCLiveLinkEditor/Private/VMCLiveLinkRetargetActorFactory.cpp
+++ b/Plugins/VMCLiveLink/Source/VMCLiveLinkEditor/Private/VMCLiveLinkRetargetActorFactory.cpp
@@ -1,3 +1,4 @@
+// Copyright (c) 2026 Lifelike & Believable Animation Design, Inc. | Athomas Goldberg. All Rights Reserved.
 #include "VMCLiveLinkRetargetActorFactory.h"
 #include "VMCLiveLinkEditorModule.h"
 #include "AssetRegistry/AssetRegistryModule.h"

--- a/Plugins/VMCLiveLink/Source/VMCLiveLinkEditor/Private/VMCLiveLinkRetargetActorFactory.h
+++ b/Plugins/VMCLiveLink/Source/VMCLiveLinkEditor/Private/VMCLiveLinkRetargetActorFactory.h
@@ -1,3 +1,4 @@
+// Copyright (c) 2026 Lifelike & Believable Animation Design, Inc. | Athomas Goldberg. All Rights Reserved.
 #pragma once
 
 #include "CoreMinimal.h"

--- a/scripts/add_copyright_headers.py
+++ b/scripts/add_copyright_headers.py
@@ -12,8 +12,10 @@ Modes:
 
 Notes:
 - Strips any UTF-8 BOM (U+FEFF) that may exist at the start of the file.
-- Reads with utf-8-sig and writes with utf-8 (no BOM) to prevent BOM from
-  appearing before includes/pragma lines.
+- Only the first line is ever decoded as text (to detect/build the header);
+  everything after it is read and rewritten as untouched raw bytes, so a
+  file that isn't valid UTF-8 past the header line can't get silently
+  mangled by a lossy decode/re-encode round-trip.
 - Preserves existing line endings (LF or CRLF) when inserting/updating the
   header.
 - Handles year ranges with hyphen or en dash.
@@ -27,20 +29,21 @@ import sys
 
 CURRENT_YEAR = datetime.date.today().year
 DEFAULT_HOLDER = "Lifelike & Believable Animation Design, Inc. | Athomas Goldberg"
+BOM = b"\xef\xbb\xbf"
 
 YEAR_RANGE_SPLIT_RE = re.compile(r"[–-]")  # hyphen or en dash
 HEADER_LINE_RE = re.compile(r"//\s*Copyright\s*\(c\)\s*([0-9]{4}(?:[–-][0-9]{4})?)\s+.+", re.I)
 
 
-def detect_eol(lines):
-    # Try to preserve existing newline style
-    for l in lines:
-        if l.endswith("\r\n"):
-            return "\r\n"
-        if l.endswith("\n"):
-            return "\n"
-    # Default to '\n' if we can't detect
-    return "\n"
+def split_first_line(raw):
+    """Split raw bytes into (first_line_bytes, eol_bytes, rest_bytes). eol_bytes
+    is b"" if the file has no newline (single line, nothing to preserve after it)."""
+    idx = raw.find(b"\n")
+    if idx == -1:
+        return raw, b"", b""
+    if idx > 0 and raw[idx - 1:idx] == b"\r":
+        return raw[:idx - 1], b"\r\n", raw[idx + 1:]
+    return raw[:idx], b"\n", raw[idx + 1:]
 
 
 def normalize_years(years_str):
@@ -66,21 +69,20 @@ def desired_header_line(holder, years):
 def process_file(path, holder, verify):
     """Returns the path if it has a missing/outdated header, else None.
     In fix mode (verify=False), also rewrites the file and returns None."""
-    # Read using utf-8-sig to automatically remove BOM if present
-    with open(path, "r", encoding="utf-8-sig", errors="ignore", newline="") as f:
-        lines = f.readlines()
+    with open(path, "rb") as f:
+        raw = f.read()
 
-    if not lines:
+    if not raw:
         return None
 
-    # Defensive: strip any lingering BOM at the very start of the file
-    if lines[0].startswith("﻿"):
-        lines[0] = lines[0].lstrip("﻿")
+    if raw.startswith(BOM):
+        raw = raw[len(BOM):]
 
-    eol = detect_eol(lines)
-
-    # Work with the first line without its trailing newline
-    first_line_no_eol = lines[0].rstrip("\r\n")
+    first_bytes, eol, rest = split_first_line(raw)
+    # Only this slice is ever decoded, and only to detect/parse an existing
+    # header - the decoded string is never written back, so a lossy decode
+    # here (errors="ignore") can't corrupt anything.
+    first_line_no_eol = first_bytes.decode("utf-8", errors="ignore")
 
     m = HEADER_LINE_RE.match(first_line_no_eol)
     if m:
@@ -90,15 +92,15 @@ def process_file(path, holder, verify):
             return None
         if verify:
             return path
-        lines[0] = desired + eol
+        new_raw = desired.encode("utf-8") + (eol or b"\n") + rest
     else:
         desired = desired_header_line(holder, str(CURRENT_YEAR))
         if verify:
             return path
-        lines.insert(0, desired + eol)
+        new_raw = desired.encode("utf-8") + b"\n" + raw
 
-    with open(path, "w", encoding="utf-8", newline="") as f:
-        f.writelines(lines)
+    with open(path, "wb") as f:
+        f.write(new_raw)
     print(f"Updated: {path}")
     return None
 

--- a/scripts/add_copyright_headers.py
+++ b/scripts/add_copyright_headers.py
@@ -1,24 +1,35 @@
 #!/usr/bin/env python3
 """
-Scan Unreal plugin Source/ directory and ensure every .h/.cpp file starts with a copyright header.
-If missing, add it. If present, update year range to include current year.
+Scan an Unreal plugin's Source/ directory and ensure every .h/.cpp file starts
+with a copyright header.
 
-This version:
+Modes:
+- Default (fix): insert a header where one is missing, and normalize existing
+  headers (holder text, year range extended to include the current year).
+- --verify: check only, write nothing. Prints every file whose header is
+  missing or doesn't match the expected text and exits non-zero if any are
+  found. Intended for CI.
+
+Notes:
 - Strips any UTF-8 BOM (U+FEFF) that may exist at the start of the file.
-- Reads with utf-8-sig and writes with utf-8 (no BOM) to prevent BOM from appearing before includes/pragma lines.
-- Preserves existing line endings (LF or CRLF) when inserting/updating the header.
+- Reads with utf-8-sig and writes with utf-8 (no BOM) to prevent BOM from
+  appearing before includes/pragma lines.
+- Preserves existing line endings (LF or CRLF) when inserting/updating the
+  header.
 - Handles year ranges with hyphen or en dash.
 """
 
+import argparse
+import datetime
 import os
 import re
-import datetime
 import sys
 
-HEADER_TEXT = "// Copyright (c) {years} Lifelike & Believable Animation Design, Inc. | Athomas Goldberg. All Rights Reserved."
 CURRENT_YEAR = datetime.date.today().year
+DEFAULT_HOLDER = "Lifelike & Believable Animation Design, Inc. | Athomas Goldberg"
 
 YEAR_RANGE_SPLIT_RE = re.compile(r"[–-]")  # hyphen or en dash
+HEADER_LINE_RE = re.compile(r"//\s*Copyright\s*\(c\)\s*([0-9]{4}(?:[–-][0-9]{4})?)\s+.+", re.I)
 
 
 def detect_eol(lines):
@@ -38,72 +49,94 @@ def normalize_years(years_str):
         parts = YEAR_RANGE_SPLIT_RE.split(years_str, maxsplit=1)
         try:
             start_year = int(parts[0].strip())
-        except Exception:
+        except ValueError:
             start_year = CURRENT_YEAR
         return f"{start_year}-{CURRENT_YEAR}"
-    else:
-        try:
-            y = int(years_str)
-        except Exception:
-            y = CURRENT_YEAR
-        return f"{y}-{CURRENT_YEAR}" if y != CURRENT_YEAR else f"{CURRENT_YEAR}"
+    try:
+        y = int(years_str)
+    except ValueError:
+        y = CURRENT_YEAR
+    return f"{y}-{CURRENT_YEAR}" if y != CURRENT_YEAR else f"{CURRENT_YEAR}"
 
 
-def process_file(path):
+def desired_header_line(holder, years):
+    return f"// Copyright (c) {years} {holder}. All Rights Reserved."
+
+
+def process_file(path, holder, verify):
+    """Returns the path if it has a missing/outdated header, else None.
+    In fix mode (verify=False), also rewrites the file and returns None."""
     # Read using utf-8-sig to automatically remove BOM if present
     with open(path, "r", encoding="utf-8-sig", errors="ignore", newline="") as f:
         lines = f.readlines()
 
     if not lines:
-        return
+        return None
 
     # Defensive: strip any lingering BOM at the very start of the file
-    if lines and lines[0].startswith("\ufeff"):
-        lines[0] = lines[0].lstrip("\ufeff")
+    if lines[0].startswith("﻿"):
+        lines[0] = lines[0].lstrip("﻿")
 
     eol = detect_eol(lines)
 
     # Work with the first line without its trailing newline
     first_line_no_eol = lines[0].rstrip("\r\n")
-    updated = False
 
-    # Regex to detect an existing copyright header on the first line
-    # Capture the year or year range and the holder text (unused, but tolerated)
-    m = re.match(r"//\s*Copyright\s*\(c\)\s*([0-9]{4}(?:[–-][0-9]{4})?)\s+(.+)", first_line_no_eol, flags=re.I)
+    m = HEADER_LINE_RE.match(first_line_no_eol)
     if m:
-        years_str = m.group(1)
-        years = normalize_years(years_str)
-        desired_header_line = f"{HEADER_TEXT.format(years=years)}"
-        if first_line_no_eol != desired_header_line:
-            lines[0] = desired_header_line + eol
-            updated = True
+        years = normalize_years(m.group(1))
+        desired = desired_header_line(holder, years)
+        if first_line_no_eol == desired:
+            return None
+        if verify:
+            return path
+        lines[0] = desired + eol
     else:
-        # Insert a new header at the top
-        years = str(CURRENT_YEAR)
-        new_header = f"{HEADER_TEXT.format(years=years)}{eol}"
-        lines.insert(0, new_header)
-        updated = True
+        desired = desired_header_line(holder, str(CURRENT_YEAR))
+        if verify:
+            return path
+        lines.insert(0, desired + eol)
 
-    if updated:
-        # Write as utf-8 (no BOM) and preserve exact newlines in 'lines'
-        with open(path, "w", encoding="utf-8", newline="") as f:
-            f.writelines(lines)
-        print(f"Updated: {path}")
+    with open(path, "w", encoding="utf-8", newline="") as f:
+        f.writelines(lines)
+    print(f"Updated: {path}")
+    return None
 
 
-def main():
-    if len(sys.argv) < 2:
-        print("Usage: add_copyright_headers.py <PluginRoot>")
-        sys.exit(1)
-    root = sys.argv[1]
-    source_root = os.path.join(root, "Source")
-    if not os.path.isdir(source_root):
-        print(f"No Source folder under {root}")
-        sys.exit(1)
+def iter_source_files(source_root):
     for dirpath, _, filenames in os.walk(source_root):
         for fn in filenames:
             if fn.endswith((".h", ".hpp", ".cpp", ".cxx")):
-                process_file(os.path.join(dirpath, fn))
+                yield os.path.join(dirpath, fn)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("plugin_root", help="Path to the plugin root folder (contains Source/).")
+    parser.add_argument("--holder", default=DEFAULT_HOLDER,
+                         help="Copyright holder text to enforce (default: %(default)r).")
+    parser.add_argument("--verify", action="store_true",
+                         help="Check only; do not modify files. Exit non-zero if any header is missing or outdated.")
+    args = parser.parse_args()
+
+    source_root = os.path.join(args.plugin_root, "Source")
+    if not os.path.isdir(source_root):
+        print(f"No Source folder under {args.plugin_root}")
+        sys.exit(1)
+
+    violations = [
+        path
+        for path in iter_source_files(source_root)
+        if process_file(path, args.holder, args.verify)
+    ]
+
+    if args.verify:
+        if violations:
+            print("Missing or outdated copyright header:")
+            for v in violations:
+                print(f"  {v}")
+            sys.exit(1)
+        print("All copyright headers OK.")
 
 
 if __name__ == "__main__":

--- a/scripts/verify_copyright_headers.ps1
+++ b/scripts/verify_copyright_headers.ps1
@@ -1,0 +1,78 @@
+<#
+.SYNOPSIS
+  Verify every .h/.hpp/.cpp/.cxx file under a plugin's Source/ directory starts
+  with an up-to-date copyright header. Check only - never modifies files.
+
+.DESCRIPTION
+  PowerShell port of add_copyright_headers.py's --verify mode, kept in sync by
+  hand. Exists so CI doesn't depend on Python being available on the runner
+  (self-hosted Windows runners here don't reliably have it, and installing it
+  via actions/setup-python isn't reliable on locked-down runners either).
+  For fixing headers locally, use add_copyright_headers.py instead - this
+  script only checks.
+
+.PARAMETER PluginDir
+  Path to the plugin root folder (contains Source/).
+
+.PARAMETER Holder
+  Copyright holder text to enforce.
+
+.EXAMPLE
+  .\verify_copyright_headers.ps1 -PluginDir "Plugins\VMCLiveLink" -Holder "Lifelike & Believable Animation Design, Inc. | Athomas Goldberg"
+#>
+
+param(
+  [Parameter(Mandatory=$true)][string]$PluginDir,
+  [Parameter(Mandatory=$true)][string]$Holder
+)
+
+$ErrorActionPreference = "Stop"
+$CurrentYear = (Get-Date).Year
+
+$SourceRoot = Join-Path $PluginDir "Source"
+if (-not (Test-Path $SourceRoot)) {
+  Write-Error "No Source folder under $PluginDir"
+  exit 1
+}
+
+$HeaderLineRegex = '^//\s*Copyright\s*\(c\)\s*(\d{4}(?:[–-]\d{4})?)\s+.+'
+
+function Get-DesiredHeader([string]$Years) {
+  return "// Copyright (c) $Years $Holder. All Rights Reserved."
+}
+
+function Get-NormalizedYears([string]$YearsStr) {
+  if ($YearsStr -match '^(\d{4})[–-](\d{4})$') {
+    $startYear = [int]$Matches[1]
+    return "$startYear-$CurrentYear"
+  }
+  $y = [int]$YearsStr
+  if ($y -ne $CurrentYear) { return "$y-$CurrentYear" }
+  return "$CurrentYear"
+}
+
+$Violations = New-Object System.Collections.Generic.List[string]
+$Files = Get-ChildItem -Path $SourceRoot -Recurse -File -Include *.h,*.hpp,*.cpp,*.cxx
+
+foreach ($File in $Files) {
+  $FirstLine = Get-Content -LiteralPath $File.FullName -TotalCount 1 -Encoding UTF8
+  if ($null -eq $FirstLine) { continue }
+
+  if ($FirstLine -match $HeaderLineRegex) {
+    $Years = Get-NormalizedYears $Matches[1]
+    $Desired = Get-DesiredHeader $Years
+    if ($FirstLine.TrimEnd() -ne $Desired) {
+      $Violations.Add($File.FullName)
+    }
+  } else {
+    $Violations.Add($File.FullName)
+  }
+}
+
+if ($Violations.Count -gt 0) {
+  Write-Host "Missing or outdated copyright header:"
+  foreach ($V in $Violations) { Write-Host "  $V" }
+  exit 1
+}
+
+Write-Host "All copyright headers OK."


### PR DESCRIPTION
## Summary
Supersedes #92, which was built on a branch that had diverged from `main` before ~9 later PRs restructured the VMCLiveLink plugin (SourceFactory moved modules, new Mapping Asset system, etc.), so its diff no longer applied cleanly. This reapplies the still-valid findings from that audit against current `main`. (Two findings from #92 — dead `bMetersToCm`/`YawOffsetDeg` config, and a duplicated map-apply block in `PushStaticData` — turned out to already be fixed independently by the later restructuring, so they're not repeated here.)

**1. Null-deref crash in `PushFrame()` when root arrives only via `Root/Pos`**
`FVMCLiveLinkSource::PushFrame()` built the root bone's transform via `LocalPose.Find(SrcName)` and dereferenced the result unconditionally. `LocalPose` is only populated by `/VMC/Ext/Bone/Pos` messages, while root data arrives via the separate `/VMC/Ext/Root/Pos` message into `PendingRoot`/`LocalRoot`, which was captured but never read. Any sender following the standard VMC pattern — root sent once via `Root/Pos`, not duplicated as a named `Bone/Pos` — crashes the Editor/game on the first `/VMC/Ext/Blend/Apply`. This includes the repo's own `vmc_sender.py` sample. Fix: fall back to `LocalRoot` when no explicit `"root"` entry exists in `LocalPose`.

**2. Dead remapper hook + subject-bootstrap race**
`RefreshStaticMapsIfNeeded()`, `StaticNameRemapper`, and `LastRemapVersion` were never called/used anywhere — the live path reads the remapper from subject settings via `RefreshStaticMapsFromSettings()` instead. Separately, the `/VMC/Ext/Blend/Apply` handler deferred `EnsureSubjectSettingsWithDefaults()` (creates the subject + attaches the default remapper) via `AsyncTask(GameThread, ...)`, then immediately called `PushStaticData()`/`PushFrame()` synchronously in the same function. Since OSC messages are already dispatched on the Game Thread, that AsyncTask wasn't hopping threads — it just queued the lambda to run after the pushes below already ran, letting the subject get auto-created with generic default settings before the deferred task attached the intended remapper on a freshly-added source's first Apply.

**3. CI copyright-header check was a no-op**
`add_copyright_headers.py` never parsed CLI arguments beyond the plugin root, so the workflow's `--verify`/`--holder` flags were silently ignored — the script always rewrote files and exited 0, so the CI step could never fail. Added real argument parsing (kept for local/manual use), and since this self-hosted runner doesn't reliably have Python (confirmed — `actions/setup-python` also fails here), added a pure-PowerShell port (`verify_copyright_headers.ps1`) and switched CI to use that instead. Also fixed the workflow's holder text (missing "| Athomas Goldberg") and gated the release-creation steps to the `release/*` tag-push trigger — they had no condition, so any `workflow_dispatch` test run would also cut a public GitHub Release.

## Not included here
`.venv/` untracking is split into a separate PR (#see below) to keep this diff's file count low enough for review tooling (Copilot bailed on #92's review specifically because it exceeded 300 changed files).

## Test plan
- [ ] Load the plugin in UE 5.6, add a VMC Live Link source, run `vmc_sender.py`, confirm the Editor no longer crashes on the first frame and the root bone animates correctly.
- [ ] Verify behavior is unchanged for senders that do send an explicit `Bone/Pos` named `"root"`.
- [ ] Add a fresh VMC source and confirm the default remapper is attached on the very first `Blend/Apply` (not just subsequent ones).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
