### PR TITLE
Fix broken/stale documentation (README rendering, VRM 1.0 status)

### DIFF
--- a/PRODUCTION_READINESS_ACTION_ITEMS.md
+++ b/PRODUCTION_READINESS_ACTION_ITEMS.md
@@ -548,21 +548,21 @@ Create video tutorial series for YouTube/documentation site.
 ## Priority 4: Low (Future Versions)
 
 ### 4.1 VRM 1.0 Support
-- **Status:** ❌ Not Started
+- **Status:** ✅ Complete (spring bones); VRM 1.0 mesh/skeleton import already supported
 - **Priority:** LOW
-- **Effort:** 3-4 weeks
 - **Owner:** TBD
-- **Due Date:** v1.3+
 
 **Description:**
-Add support for VRM 1.0 format (currently supports VRM 0.x).
+VRM 1.0 support has landed: `VRMSpringBonesParser.cpp` parses both the
+VRM 0.x (`secondaryAnimation`) and VRM 1.0 (`VRMC_springBone`) spring bone
+formats, `VRM::ValidateSpringConfig()` is wired into the import pipeline to
+reject malformed VRM 1.0 spring configs before they reach the runtime solver,
+and VRM 0.x compatibility is unaffected. The plugin README's Known
+Limitations section already reflects VRM 1.0 support.
 
-**Requirements:**
-- [ ] Update cgltf or use alternate parser
-- [ ] Parse VRM 1.0 extensions
-- [ ] Support new spring bone format
-- [ ] Update validation logic
-- [ ] Maintain backward compatibility with VRM 0.x
+**Remaining:**
+- [ ] Broader glTF 2.0 feature coverage beyond the VRM-specific subset
+      (not VRM-1.0-specific; see PRODUCTION_READINESS_ANALYSIS.md §9.2)
 
 ---
 

--- a/PRODUCTION_READINESS_ANALYSIS.md
+++ b/PRODUCTION_READINESS_ANALYSIS.md
@@ -844,7 +844,6 @@ return HeadWS + Dir * State.WorldBoneLength;
    - <2% bug rate per release
 
 4. **Feature Expansion**
-   - VRM 1.0 support
    - Advanced spring bone features
    - Performance optimizations (SIMD)
    - Additional VMC protocol extensions

--- a/Plugins/VRMInterchange/README.md
+++ b/Plugins/VRMInterchange/README.md
@@ -7,7 +7,7 @@ The VRM Interchange plugin is a comprehensive VRM (.vrm) importer for Unreal Eng
 ## Features
 
 ### Core Import Capabilities
-- **VRM Format Support**: Imports VRM 0.x files (glTF 2.0-based avatar format)
+- **VRM Format Support**: Imports VRM 0.x and VRM 1.0 files (glTF 2.0-based avatar format)
 - **Skeletal Mesh**: Full skeleton hierarchy with proper bone orientations
 - **Textures**: Automatic texture import with proper material setup
 - **Blend Shapes**: Morph target support for facial expressions
@@ -302,7 +302,7 @@ This plugin is part of the VMCLiveLink project. For issues, feature requests, or
 
 ## License
 
-Copyright (c) 2024 Lifelike & Believable Animation Design, Inc. All Rights Reserved.
+Copyright (c) 2025-2026 Lifelike & Believable Animation Design, Inc. | Athomas Goldberg. All Rights Reserved.
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -16,37 +16,49 @@ VMCLiveLink is more than a plugin — it’s part of a larger movement: treating
 
 Whether you’re crafting an XR dance performance, streaming a VTuber show, or building a virtual stage for a live audience, VMCLiveLink gives you the bridge between raw performance and expressive digital presence.
 
+## Plugins in This Repo
+
+- **[VMCLiveLink](Plugins/VMCLiveLink)** — receives the VMC protocol over OSC and streams it into Unreal’s Live Link system.
+- **[VRMInterchange](Plugins/VRMInterchange)** — imports VRM avatars (spring bone physics, IK rigs, Live Link actor scaffolding). See its [README](Plugins/VRMInterchange/README.md) for details.
+
 ## Getting Started
 
 1. Clone the repo (requires [Git LFS](https://git-lfs.github.com/)):
    ```bash
-   git clone https://github.com/atgoldberg/VMCLiveLink.git
+   git clone https://github.com/lifelike-and-believable/VMCLiveLink.git
    cd VMCLiveLink
    git lfs pull
+   ```
 
 ## 🚀 Fab Plugin CI/CD
 
-This repository includes automated GitHub Actions to keep the plugin Fab-ready.
+This repository includes automated GitHub Actions to keep the plugins Fab-ready.
 
 ### 🔎 Verify Build & Package
-[![Fab Plugin Builds](https://github.com/<your-org>/<your-repo>/actions/workflows/fab-plugin-build.yml/badge.svg)](https://github.com/<your-org>/<your-repo>/actions/workflows/fab-plugin-build.yml)
+[![Fab Plugin Builds](https://github.com/lifelike-and-believable/VMCLiveLink/actions/workflows/fab-plugin-build.yml/badge.svg)](https://github.com/lifelike-and-believable/VMCLiveLink/actions/workflows/fab-plugin-build.yml)
 
 Runs on tag push (`release/*`) or manually via **Actions → Fab Plugin Builds**:
-- Verifies all source files have a valid copyright header.
-- Builds the plugin for the specified Unreal Engine roots/versions.
-- Produces Fab-ready zips as downloadable artifacts.
+- Verifies all source files in `Plugins/VMCLiveLink` have a valid copyright header.
+- Builds both the VMCLiveLink and VRMInterchange plugins against the UE 5.6 engine root configured in the workflow.
+- Produces Fab-ready zips (a combined package plus one per plugin) as downloadable artifacts.
+- On a `release/*` tag push, also publishes those zips to a GitHub Release. Manual `workflow_dispatch` runs skip release creation and only produce the build artifacts.
 
 **Usage:**
-1. Go to **Actions → Fab Plugin Builds → Run workflow**.
-2. Fill in:
-   - `plugin_dir` → path to plugin folder (default: `Plugins/VMCLiveLink`)
-   - `engine_roots` → comma-separated UE roots (e.g. `C:\UE\5.4,C:\UE\5.5,C:\UE\5.6`)
-   - `engine_versions` → matching versions (e.g. `5.4.0,5.5.0,5.6.0`)
+- To cut a release: push a tag matching `release/*` (e.g. `release/1.2.0`).
+- To test a build without releasing: go to **Actions → Fab Plugin Builds → Run workflow** and run it against any branch. The engine root/version and plugin paths are fixed in the workflow file, not configurable per-run.
 
 ### 🛠️ Auto-fix Headers
-[![Auto-fix Headers](https://github.com/<your-org>/<your-repo>/actions/workflows/header-autofix.yml/badge.svg)](https://github.com/<your-org>/<your-repo>/actions/workflows/header-autofix.yml)
+[![Auto-fix Headers](https://github.com/lifelike-and-believable/VMCLiveLink/actions/workflows/header-autofix.yml/badge.svg)](https://github.com/lifelike-and-believable/VMCLiveLink/actions/workflows/header-autofix.yml)
 
 Ensures every `.h/.cpp` file starts with:
 
 ```cpp
-// Copyright (c) YYYY Lifelike & Believable Animation Design, Inc. All Rights Reserved.
+// Copyright (c) YYYY Lifelike & Believable Animation Design, Inc. | Athomas Goldberg. All Rights Reserved.
+```
+
+**Usage:**
+1. Go to **Actions → Auto-fix Headers → Run workflow**.
+2. Fill in:
+   - `plugin_dir` → path to the plugin folder (default: `Plugins/VMCLiveLink`)
+   - `holder` → copyright holder text to enforce (default: `Lifelike & Believable Animation Design, Inc. | Athomas Goldberg`)
+3. If any headers were missing or out of date, the workflow commits the fix on a new branch and opens a pull request.


### PR DESCRIPTION
## Summary
A documentation review turned up one real rendering bug and several stale claims:

**README.md**
- An unterminated ` ```bash ` code fence in "Getting Started" was swallowing every heading and section after it (the entire "Fab Plugin CI/CD" section) into a literal code block on GitHub instead of rendering as markdown.
- Badge/action links used placeholder `<your-org>/<your-repo>` URLs, and the clone instructions pointed at the old `atgoldberg/VMCLiveLink` location instead of the current `lifelike-and-believable/VMCLiveLink`.
- The copyright header sample was missing `| Athomas Goldberg`, which CI actually enforces as part of the holder text.
- The Fab Plugin Builds "Usage" steps described `plugin_dir`/`engine_roots`/`engine_versions` as fillable `workflow_dispatch` inputs — that workflow has no such inputs; its configuration is fixed in the file. Added the Auto-fix Headers workflow's actual usage steps, which were missing entirely.
- Added a "Plugins in This Repo" section — the README never mentioned VRMInterchange, which lives in this same repo and is built by the same CI workflow.

**Plugins/VRMInterchange/README.md**
- The Features list said "Imports VRM 0.x files," while this same file's own Known Limitations section says "Supports VRM 0.x and VRM 1.0" (correct — `VRMSpringBonesParser.cpp` parses both formats). Fixed the inconsistency.
- Updated the stale 2024 copyright line to match the enforced format.

**PRODUCTION_READINESS_ACTION_ITEMS.md / PRODUCTION_READINESS_ANALYSIS.md**
- Both listed VRM 1.0 support as not-started / a future roadmap item. It's implemented (and got a bug fix in #93). Marked the action item complete and removed the stale roadmap bullet.

## Not changed
- `VRM_SpringBones_Physics_Analysis.md` has several headings with literal `?` characters where emoji apparently didn't survive an earlier encoding round-trip (e.g. `## ? Correctly Implemented Aspects`). Left alone rather than guessing at replacement emoji with no strong signal for what they originally were — flagging here in case someone wants to fix it with the original intent in hand.
- `Planning Docs/`, `postmortems/`, and the bulk of `PRODUCTION_READINESS_ANALYSIS.md`'s findings/scores are point-in-time records rather than living docs, so left untouched beyond the one factual VRM 1.0 correction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01MW7wvCCJMYkutmehmWzqHU)_